### PR TITLE
fix: gui: fix the 'SetLabelText() failed' error caption on the medium…

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -508,7 +508,7 @@ void PrintCLIorLabel(void *unused, char *format, ...)
       while(*c == '\n')          /* Remove trailing newlines */
 	*c-- = 0;
 
-      SetLabelText(label, tmp);  /* converts to utf8 by itself */
+      SetLabelText(label, "%s", tmp);  /* converts to utf8 by itself */
    
       g_free(tmp);
    }


### PR DESCRIPTION
…-info window

This is a cosmetic fix only, this bug is present since at least 0.72,
but only became apparent since commit 4cebc5af, which made the error
no longer silently ignored (v0.72.3).

Fixes one of the reported problem of issue #19.