### PR TITLE
fix: allow blank media in medium-info

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -877,7 +877,7 @@ void ReadSector(char *arg)
 
    /*** Open the device */
 
-   image = OpenImageFromDevice(Closure->device);
+   image = OpenImageFromDevice(Closure->device, 0);
    if(!image)
      Stop(_("Can't open %s:\n%s"), Closure->imageName, strerror(errno));
 
@@ -931,7 +931,7 @@ void RawSector(char *arg)
 
    /*** Open the device */
 
-   image = OpenImageFromDevice(Closure->device);
+   image = OpenImageFromDevice(Closure->device, 0);
    if(!image)
      Stop(_("Can't open %s:\n%s"), Closure->imageName, strerror(errno));
    sense = &image->dh->sense;

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -894,7 +894,7 @@ typedef struct _Image
 } Image;
 
 Image* OpenImageFromFile(char*, int, mode_t);
-Image* OpenImageFromDevice(char*);   /* really in scsi-layer.h */
+Image* OpenImageFromDevice(char*, int);   /* really in scsi-layer.h */
 Image* OpenEccFileForImage(Image*, char*, int, mode_t);
 int ReportImageEccInconsistencies(Image*);
 int GetImageFingerprint(Image*, guint8*, guint64);

--- a/src/medium-info.c
+++ b/src/medium-info.c
@@ -104,7 +104,7 @@ void PrintMediumInfo(void *mi_ptr)
       print_defaults(mi);
 #endif
 
-   image = OpenImageFromDevice(Closure->device);
+   image = OpenImageFromDevice(Closure->device, 2 /* allow blanks, see comment in OpenImageFromDevice() */);
    if(!image) return;
    dh = image->dh;
    QueryBlankCapacity(dh);

--- a/src/read-adaptive.c
+++ b/src/read-adaptive.c
@@ -626,7 +626,7 @@ static void open_and_determine_mode(read_closure *rc)
  
    /* open the device */
 
-   rc->medium = OpenImageFromDevice(Closure->device);
+   rc->medium = OpenImageFromDevice(Closure->device, 0);
    rc->dh = rc->medium->dh;
    rc->readMode = IMAGE_ONLY;
 

--- a/src/read-linear.c
+++ b/src/read-linear.c
@@ -832,7 +832,7 @@ void ReadMediumLinear(gpointer data)
         and possibly the respective ecc file.
         The on disk image is maintained in rc->reader|writerImage. */
 
-   rc->image = OpenImageFromDevice(Closure->device);
+   rc->image = OpenImageFromDevice(Closure->device, 0);
    Closure->readErrors = Closure->crcErrors = rc->readOK = 0;
 
    /*** Save some useful information for the missing sector marker */


### PR DESCRIPTION
This resolves the second part of issue #19.

This bug was present since upstream v0.79.5