### PR TITLE
Support HD-DVD

### DIFF
--- a/src/scsi-layer.h
+++ b/src/scsi-layer.h
@@ -235,6 +235,10 @@ typedef struct _DeviceHandle
 #define BD_R           0x41
 #define BD_RE          0x42
 
+#define HD_DVD         0x50
+#define HD_DVD_R       0x51
+#define HD_DVD_RW      0x52
+
 #define UNSUPPORTED    0x00 
 
 /* transport io modes */


### PR DESCRIPTION
Fixes https://github.com/speed47/dvdisaster/issues/83.

I only have a couple of HD-DVD's to test, only one drive that supports it, and no (re)writeable HD-DVD's...
HD-DVD-ROM is confirmed to work, HD-DVD-R and HD-DVD-RW is my best guess based on the scarce information I could find in similar code hosted on github.

HD-DVD-RAM is apparently not a thing, although is has a book type that is a logical extension of DVD-RAM.