### PR TITLE
Fix read of initialized memory in `FreeClosure` when logging is enabled

### DIFF
--- a/src/closure.c
+++ b/src/closure.c
@@ -718,6 +718,9 @@ void FreeClosure()
      g_free(Closure->readAdaptiveErrorMsg);
 #endif /* WITH_GUI_YES */
 
+   if(Closure->crcBuf)
+     FreeCrcBuf(Closure->crcBuf);
+
    cond_free(Closure->cookedVersion);
    cond_free(Closure->versionString);
    cond_free(Closure->device);
@@ -740,9 +743,6 @@ void FreeClosure()
    cond_free(Closure->simulateCD);
    cond_free(Closure->dDumpDir);
    cond_free(Closure->dDumpPrefix);
-
-   if(Closure->crcBuf)
-     FreeCrcBuf(Closure->crcBuf);
 
    if(Closure->logString)
       g_string_free(Closure->logString, TRUE);

--- a/src/closure.c
+++ b/src/closure.c
@@ -678,43 +678,7 @@ void FreeClosure()
 #ifdef WITH_GUI_YES
    if(Closure->guiMode)
      update_dotfile();
-#endif
-   
-   cond_free(Closure->cookedVersion);
-   cond_free(Closure->versionString);
-   cond_free(Closure->device);
-   cond_free_ptr_array(Closure->deviceNames);
-   cond_free_ptr_array(Closure->deviceNodes);
-   cond_free(Closure->imageName);
-   cond_free(Closure->eccName);
-   cond_free(Closure->redundancy);
 
-   CallMethodDestructors();
-   cond_free_ptr_array(Closure->methodList);
-
-   cond_free(Closure->methodName);
-   cond_free(Closure->homeDir);
-   cond_free(Closure->dotFile);
-   cond_free(Closure->logFile);
-   cond_free(Closure->binDir);
-   cond_free(Closure->docDir);
-   cond_free(Closure->errorTitle);
-   cond_free(Closure->simulateCD);
-   cond_free(Closure->dDumpDir);
-   cond_free(Closure->dDumpPrefix);
-
-   if(Closure->crcBuf)
-     FreeCrcBuf(Closure->crcBuf);
-   
-   if(Closure->logString)
-      g_string_free(Closure->logString, TRUE);
-
-   if(Closure->logLock)
-   {  g_mutex_clear(Closure->logLock);
-      g_free(Closure->logLock);
-   }
-
-#ifdef WITH_GUI_YES
    if(Closure->prefsContext)
       GuiFreePreferences(Closure->prefsContext);
 
@@ -753,6 +717,40 @@ void FreeClosure()
    if(Closure->readAdaptiveErrorMsg)
      g_free(Closure->readAdaptiveErrorMsg);
 #endif /* WITH_GUI_YES */
+
+   cond_free(Closure->cookedVersion);
+   cond_free(Closure->versionString);
+   cond_free(Closure->device);
+   cond_free_ptr_array(Closure->deviceNames);
+   cond_free_ptr_array(Closure->deviceNodes);
+   cond_free(Closure->imageName);
+   cond_free(Closure->eccName);
+   cond_free(Closure->redundancy);
+
+   CallMethodDestructors();
+   cond_free_ptr_array(Closure->methodList);
+
+   cond_free(Closure->methodName);
+   cond_free(Closure->homeDir);
+   cond_free(Closure->dotFile);
+   cond_free(Closure->logFile);
+   cond_free(Closure->binDir);
+   cond_free(Closure->docDir);
+   cond_free(Closure->errorTitle);
+   cond_free(Closure->simulateCD);
+   cond_free(Closure->dDumpDir);
+   cond_free(Closure->dDumpPrefix);
+
+   if(Closure->crcBuf)
+     FreeCrcBuf(Closure->crcBuf);
+
+   if(Closure->logString)
+      g_string_free(Closure->logString, TRUE);
+
+   if(Closure->logLock)
+   {  g_mutex_clear(Closure->logLock);
+      g_free(Closure->logLock);
+   }
    
    g_free(Closure);
 }


### PR DESCRIPTION
`FreeClosure` calls a couple of functions that may do logging. But it frees `Closure->logFile` before that, after which the logging code reads uninitialized memory.

Valgrind report from before:
```
==38169== Syscall param openat(filename) points to unaddressable byte(s)
==38169==    at 0x5759B55: open (open64.c:41)
==38169==    by 0x56DA8DE: _IO_file_open (fileops.c:188)
==38169==    by 0x56DAA94: _IO_file_fopen@@GLIBC_2.2.5 (fileops.c:281)
==38169==    by 0x56CED75: __fopen_internal (iofopen.c:75)
==38169==    by 0x414EAF: VPrintLogFile (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==    by 0x41A2CB: Verbose (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==    by 0x4062C4: FreeClosure (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==    by 0x403764: main (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==  Address 0x601a440 is 0 bytes inside a block of size 31 free'd
==38169==    at 0x4844B83: free (vg_replace_malloc.c:989)
==38169==    by 0x5247EC4: g_free (gmem.c:208)
==38169==    by 0x40621C: FreeClosure (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==    by 0x403764: main (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==  Block was alloc'd at
==38169==    at 0x4841866: malloc (vg_replace_malloc.c:446)
==38169==    by 0x524DCB9: g_malloc (gmem.c:100)
==38169==    by 0x5267658: g_strdup (gstrfuncs.c:323)
==38169==    by 0x405870: GuiReadDotfile (in /home/pitdicker/dev/dvdisaster/dvdisaster)
==38169==    by 0x403A9F: main (in /home/pitdicker/dev/dvdisaster/dvdisaster)
```

This PR switches the order around a bit.