### PR TITLE
Switch to cairo for drawing

### DIFF
--- a/src/closure.c
+++ b/src/closure.c
@@ -683,9 +683,6 @@ void FreeClosure()
    if(Closure->rawEditorContext)
       GuiFreeRawEditorContext(Closure->rawEditorContext);
 
-   if(Closure->drawGC)
-     g_object_unref(Closure->drawGC);
-
    cond_free(Closure->background);
    cond_free(Closure->foreground);
    cond_free(Closure->grid);

--- a/src/curve.c
+++ b/src/curve.c
@@ -169,9 +169,8 @@ void GuiUpdateCurveGeometry(Curve *curve, char *largest_left_label, int right_pa
  *** Redraw the coordinate axes
  ***/
 
-void GuiRedrawAxes(Curve *curve)
-{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(curve->widget));
-   int i,w,h,x,y; 
+void GuiRedrawAxes(cairo_t *cr, Curve *curve)
+{  int i,w,h,x,y;
    int yg=0;
    int step;
    int bottom_y;
@@ -369,9 +368,8 @@ void GuiRedrawAxes(Curve *curve)
  * Redraw the curve
  */
 
-void GuiRedrawCurve(Curve *curve, int last)
-{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(curve->widget));
-   int i,x0,x1,fy0;
+void GuiRedrawCurve(cairo_t *cr, Curve *curve, int last)
+{  int i,x0,x1,fy0;
 
    gdk_cairo_set_source_color(cr, Closure->curveColor);
    cairo_set_line_width(cr, 1.0);

--- a/src/curve.c
+++ b/src/curve.c
@@ -228,8 +228,10 @@ void GuiRedrawAxes(cairo_t *cr, Curve *curve)
 
    /* Draw and label the grid lines for the normal curve */
 
-   if(curve->maxY < 20) step = 4;
-   else step = 10;
+   if(curve->maxY > 20) step = 10;
+   else if(curve->maxY > 10) step = 4;
+   else if(curve->maxY > 4) step = 2;
+   else step = 1;
 
    for(i=0; i<=curve->maxY; i+=step)
    {  char buf[4];

--- a/src/curve.c
+++ b/src/curve.c
@@ -175,28 +175,8 @@ void GuiRedrawAxes(cairo_t *cr, Curve *curve)
    int step;
    int bottom_y;
 
-   /* Draw and label the left coordinate axis */
    cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
    cairo_set_line_width(cr, 1);
-   gdk_cairo_set_source_color(cr, Closure->foreground);
-
-   cairo_move_to(cr, curve->leftX + 0.5, curve->topY + 0.5);
-   cairo_line_to(cr, curve->leftX + 0.5, curve->bottomY + 0.5);
-   cairo_stroke(cr);
-
-   if(curve->enable & DRAW_LCURVE)
-   {  cairo_move_to(cr, curve->leftX + 0.5, curve->topLY + 0.5);
-      cairo_line_to(cr, curve->leftX + 0.5, curve->bottomLY + 0.5);
-      cairo_stroke(cr);
-   }
-
-   gdk_cairo_set_source_color(cr, Closure->curveColor);
-   GuiSetText(curve->layout, curve->leftLabel, &w, &h);
-   x = curve->leftX - w/2;
-   if(x < 5) x = 5;
-   cairo_move_to(cr, x, curve->topY - h - 5);
-   pango_cairo_show_layout(cr, curve->layout);
-
 
    /* Draw and label the grid lines for the log curve */
 
@@ -280,6 +260,26 @@ void GuiRedrawAxes(cairo_t *cr, Curve *curve)
       }
    }
 
+
+   /* Draw and label the left coordinate axis */
+   gdk_cairo_set_source_color(cr, Closure->foreground);
+
+   cairo_move_to(cr, curve->leftX + 0.5, curve->topY + 0.5);
+   cairo_line_to(cr, curve->leftX + 0.5, curve->bottomY + 0.5);
+   cairo_stroke(cr);
+
+   if(curve->enable & DRAW_LCURVE)
+   {  cairo_move_to(cr, curve->leftX + 0.5, curve->topLY + 0.5);
+      cairo_line_to(cr, curve->leftX + 0.5, curve->bottomLY + 0.5);
+      cairo_stroke(cr);
+   }
+
+   gdk_cairo_set_source_color(cr, Closure->curveColor);
+   GuiSetText(curve->layout, curve->leftLabel, &w, &h);
+   x = curve->leftX - w/2;
+   if(x < 5) x = 5;
+   cairo_move_to(cr, x, curve->topY - h - 5);
+   pango_cairo_show_layout(cr, curve->layout);
 
    /* Draw the right coordinate axis */
 

--- a/src/curve.c
+++ b/src/curve.c
@@ -170,30 +170,33 @@ void GuiUpdateCurveGeometry(Curve *curve, char *largest_left_label, int right_pa
  ***/
 
 void GuiRedrawAxes(Curve *curve)
-{  GdkDrawable *d = curve->widget->window;
+{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(curve->widget));
    int i,w,h,x,y; 
    int yg=0;
    int step;
    int bottom_y;
 
    /* Draw and label the left coordinate axis */
+   cairo_set_line_cap(cr, CAIRO_LINE_CAP_SQUARE);
+   cairo_set_line_width(cr, 1);
+   gdk_cairo_set_source_color(cr, Closure->foreground);
 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
-
-   gdk_draw_line(d, Closure->drawGC,
-		 curve->leftX, curve->topY, curve->leftX, curve->bottomY);
+   cairo_move_to(cr, curve->leftX + 0.5, curve->topY + 0.5);
+   cairo_line_to(cr, curve->leftX + 0.5, curve->bottomY + 0.5);
+   cairo_stroke(cr);
 
    if(curve->enable & DRAW_LCURVE)
-   {  gdk_draw_line(d, Closure->drawGC,
-		    curve->leftX, curve->topLY, curve->leftX, curve->bottomLY);
+   {  cairo_move_to(cr, curve->leftX + 0.5, curve->topLY + 0.5);
+      cairo_line_to(cr, curve->leftX + 0.5, curve->bottomLY + 0.5);
+      cairo_stroke(cr);
    }
 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
+   gdk_cairo_set_source_color(cr, Closure->curveColor);
    GuiSetText(curve->layout, curve->leftLabel, &w, &h);
    x = curve->leftX - w/2;
    if(x < 5) x = 5;
-   gdk_draw_layout(d, Closure->drawGC, 
-		   x, curve->topY - h - 5, curve->layout);
+   cairo_move_to(cr, x, curve->topY - h - 5);
+   pango_cairo_show_layout(cr, curve->layout);
 
 
    /* Draw and label the grid lines for the log curve */
@@ -202,37 +205,45 @@ void GuiRedrawAxes(Curve *curve)
    {  int val;
       char buf[16];
 
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->logColor);
+      gdk_cairo_set_source_color(cr, Closure->logColor);
       GuiSetText(curve->layout, curve->leftLogLabel, &w, &h);
 
       x = curve->leftX - w/2;
       if(x < 5) x = 5;
-      gdk_draw_layout(d, Closure->drawGC, 
-		      x, curve->topLY - h - 5, curve->layout);
+      cairo_move_to(cr, x, curve->topLY - h - 5);
+      pango_cairo_show_layout(cr, curve->layout);
 
       
       for(val=400; val>3; val/=2)
       {  y = GuiCurveLogY(curve, val);
-	 sprintf(buf,"%d",val);
-	 GuiSetText(curve->layout, buf, &w, &h);
-	 gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->logColor);
-	 gdk_draw_layout(d, Closure->drawGC, curve->leftX-9-w, y-h/2, curve->layout);
-	 gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
-	 gdk_draw_line(d, Closure->drawGC, curve->leftX-6, y, curve->leftX, y);
-	 gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->grid);
-	 gdk_draw_line(d, Closure->drawGC, curve->leftX, y, curve->rightX, y);
+         sprintf(buf,"%d",val);
+         GuiSetText(curve->layout, buf, &w, &h);
+         gdk_cairo_set_source_color(cr, Closure->logColor);
+         cairo_move_to(cr, curve->leftX-9-w, y-h/2);
+         pango_cairo_show_layout(cr, curve->layout);
+         gdk_cairo_set_source_color(cr, Closure->foreground);
+         cairo_move_to(cr, curve->leftX-6 + 0.5, y + 0.5);
+         cairo_line_to(cr, curve->leftX + 0.5, y + 0.5);
+         cairo_stroke(cr);
+         gdk_cairo_set_source_color(cr, Closure->grid);
+         cairo_move_to(cr, curve->leftX + 0.5, y + 0.5);
+         cairo_line_to(cr, curve->rightX + 0.5, y + 0.5);
+         cairo_stroke(cr);
 
-	 val /=2;
-	 y = GuiCurveLogY(curve, val);
-	 gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
-	 gdk_draw_line(d, Closure->drawGC, curve->leftX-3, y, curve->leftX, y);
+         val /=2;
+         y = GuiCurveLogY(curve, val);
+         gdk_cairo_set_source_color(cr, Closure->foreground);
+         cairo_move_to(cr, curve->leftX-3 + 0.5, y + 0.5);
+         cairo_line_to(cr, curve->leftX + 0.5, y + 0.5);
+         cairo_stroke(cr);
 
-	 if(curve->bottomLY-curve->topLY > 8*h)
-	 {  sprintf(buf,"%d",val);
-	    GuiSetText(curve->layout, buf, &w, &h);
-	    gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->logColor);
-	    gdk_draw_layout(d, Closure->drawGC, curve->leftX-9-w, y-h/2, curve->layout);
-	 }
+         if(curve->bottomLY-curve->topLY > 8*h)
+         {  sprintf(buf,"%d",val);
+            GuiSetText(curve->layout, buf, &w, &h);
+            gdk_cairo_set_source_color(cr, Closure->logColor);
+            cairo_move_to(cr, curve->leftX-9-w, y-h/2);
+            pango_cairo_show_layout(cr, curve->layout);
+         }
       }
    }
 
@@ -248,42 +259,55 @@ void GuiRedrawAxes(Curve *curve)
       GuiSetText(curve->layout, buf, &w, &h);
 
       y = yg = GuiCurveY(curve, i);
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
-      gdk_draw_layout(d, Closure->drawGC, curve->leftX-9-w, y-h/2, curve->layout);
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
-      gdk_draw_line(d, Closure->drawGC, curve->leftX-6, y, curve->leftX, y);
+      gdk_cairo_set_source_color(cr, Closure->curveColor);
+      cairo_move_to(cr, curve->leftX-9-w, y-h/2);
+      pango_cairo_show_layout(cr, curve->layout);
+      gdk_cairo_set_source_color(cr, Closure->foreground);
+      cairo_move_to(cr, curve->leftX-6 + 0.5, y + 0.5);
+      cairo_line_to(cr, curve->leftX + 0.5, y + 0.5);
+      cairo_stroke(cr);
 
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->grid);
-      gdk_draw_line(d, Closure->drawGC, curve->leftX, y, curve->rightX, y);
+      gdk_cairo_set_source_color(cr, Closure->grid);
+      cairo_move_to(cr, curve->leftX + 0.5, y + 0.5);
+      cairo_line_to(cr, curve->rightX + 0.5, y + 0.5);
+      cairo_stroke(cr);
 
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
+      gdk_cairo_set_source_color(cr, Closure->foreground);
       y = GuiCurveY(curve, i+step/2);
-      if(y >= curve->topY)
-        gdk_draw_line(d, Closure->drawGC, curve->leftX-3, y, curve->leftX, y);
+      if(y >= curve->topY) {
+         cairo_move_to(cr, curve->leftX-3 + 0.5, y + 0.5);
+         cairo_line_to(cr, curve->leftX + 0.5, y + 0.5);
+         cairo_stroke(cr);
+      }
    }
 
 
    /* Draw the right coordinate axis */
 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
+   gdk_cairo_set_source_color(cr, Closure->foreground);
 
-   gdk_draw_line(d, Closure->drawGC,
-		 curve->rightX, curve->topY, curve->rightX, curve->bottomY);
+   cairo_move_to(cr, curve->rightX + 0.5, curve->topY + 0.5);
+   cairo_line_to(cr, curve->rightX + 0.5, curve->bottomY + 0.5);
+   cairo_stroke(cr);
 
-   if(curve->enable & DRAW_LCURVE)
-      gdk_draw_line(d, Closure->drawGC,
-		    curve->rightX, curve->topLY, curve->rightX, curve->bottomLY);
+   if(curve->enable & DRAW_LCURVE) {
+      cairo_move_to(cr, curve->rightX + 0.5, curve->topLY + 0.5);
+      cairo_line_to(cr, curve->rightX + 0.5, curve->bottomLY + 0.5);
+      cairo_stroke(cr);
+   }
 
    /* Draw and label the bottom coordinate axis */
 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
+   gdk_cairo_set_source_color(cr, Closure->foreground);
 
-   gdk_draw_line(d, Closure->drawGC,
-		 curve->leftX, curve->bottomY, curve->rightX, curve->bottomY);
+   cairo_move_to(cr, curve->leftX + 0.5, curve->bottomY + 0.5);
+   cairo_line_to(cr, curve->rightX + 0.5, curve->bottomY + 0.5);
+   cairo_stroke(cr);
 
    if(curve->enable & DRAW_LCURVE)
-   {  gdk_draw_line(d, Closure->drawGC,
-		    curve->leftX, curve->bottomLY, curve->rightX, curve->bottomLY);
+   {  cairo_move_to(cr, curve->leftX + 0.5, curve->bottomLY + 0.5);
+      cairo_line_to(cr, curve->rightX + 0.5, curve->bottomLY + 0.5);
+      cairo_stroke(cr);
       bottom_y = curve->bottomLY;
    }
    else bottom_y = curve->bottomY;
@@ -312,21 +336,32 @@ void GuiRedrawAxes(Curve *curve)
       GuiSetText(curve->layout, buf, &w, &h);
 
       x = GuiCurveLX(curve,i)-1;
-      gdk_draw_line(d, Closure->drawGC, x, bottom_y+6, x, bottom_y);
-      gdk_draw_layout(d, Closure->drawGC, x-w/2, bottom_y+8, curve->layout);
+      cairo_move_to(cr, x + 0.5, bottom_y+6 + 0.5);
+      cairo_line_to(cr, x + 0.5, bottom_y + 0.5);
+      cairo_stroke(cr);
+      cairo_move_to(cr, x-w/2, bottom_y+8);
+      pango_cairo_show_layout(cr, curve->layout);
 
       if(i && x < curve->rightX)
-      {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->grid);
-         gdk_draw_line(d, Closure->drawGC, x, curve->bottomY-1, x, yg);
+      {  gdk_cairo_set_source_color(cr, Closure->grid);
+         cairo_move_to(cr, x + 0.5, curve->bottomY-1 + 0.5);
+         cairo_line_to(cr, x + 0.5, yg + 0.5);
+         cairo_stroke(cr);
 
-	 if(curve->enable & DRAW_LCURVE)
-	    gdk_draw_line(d, Closure->drawGC, x, curve->bottomLY-1, x, curve->topLY);
+         if(curve->enable & DRAW_LCURVE) {
+            cairo_move_to(cr, x + 0.5, curve->bottomLY-1 + 0.5);
+            cairo_line_to(cr, x + 0.5, curve->topLY + 0.5);
+            cairo_stroke(cr);
+         }
       }
 
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
+      gdk_cairo_set_source_color(cr, Closure->foreground);
       x = GuiCurveLX(curve,i+step/2)-1;
-      if(x < curve->rightX)
-        gdk_draw_line(d, Closure->drawGC, x, bottom_y+3, x, bottom_y);
+      if(x < curve->rightX) {
+         cairo_move_to(cr, x + 0.5, bottom_y+3 + 0.5);
+         cairo_line_to(cr, x + 0.5, bottom_y + 0.5);
+         cairo_stroke(cr);
+      }
    }
 }
 
@@ -335,12 +370,14 @@ void GuiRedrawAxes(Curve *curve)
  */
 
 void GuiRedrawCurve(Curve *curve, int last)
-{  int i,x0,x1,fy0,fy1;
+{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(curve->widget));
+   int i,x0,x1,fy0,fy1;
 
    x0  = GuiCurveX(curve, 0);
    fy0 = GuiCurveY(curve, curve->fvalue[0]);
 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
+   gdk_cairo_set_source_color(cr, Closure->curveColor);
+   cairo_set_line_width(cr, 1.0);
 
    /* Draw the curve */
 
@@ -351,10 +388,9 @@ void GuiRedrawCurve(Curve *curve, int last)
       {  int iy  = GuiCurveY(curve, curve->ivalue[i]);
 
 	 if(curve->ivalue[i] > 0)
-	 {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->barColor);
-	    gdk_draw_rectangle(curve->widget->window,
-			       Closure->drawGC, TRUE,
-			       x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomY-iy);
+	 {  gdk_cairo_set_source_color(cr, Closure->barColor);
+	    cairo_rectangle(cr, x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomY-iy);
+            cairo_fill(cr);
 	 }
       }
 
@@ -362,19 +398,20 @@ void GuiRedrawCurve(Curve *curve, int last)
       {  int iy  = GuiCurveLogY(curve, curve->lvalue[i]);
 
 	 if(curve->lvalue[i] > 0)
-	 {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->logColor);
-	    gdk_draw_rectangle(curve->widget->window,
-			       Closure->drawGC, TRUE,
-			       x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomLY-iy);
-	 }
+         {  gdk_cairo_set_source_color(cr, Closure->logColor);
+            cairo_rectangle(cr, x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomLY-iy);
+            cairo_fill(cr);
+         }
       }
 
       if(curve->enable & DRAW_FCURVE && curve->fvalue[i] >= 0)
       {  fy1 = GuiCurveY(curve, curve->fvalue[i]);
 
 	 if(x0 < x1)
-	 {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
-	    gdk_draw_line(curve->widget->window, Closure->drawGC, x0, fy0, x1, fy1);
+         {  gdk_cairo_set_source_color(cr, Closure->curveColor);
+            cairo_move_to(cr, x0, fy0);
+            cairo_line_to(cr, x1, fy1);
+            cairo_stroke(cr);
 	    fy0 = fy1;
 	 }
       }

--- a/src/curve.c
+++ b/src/curve.c
@@ -371,52 +371,60 @@ void GuiRedrawAxes(Curve *curve)
 
 void GuiRedrawCurve(Curve *curve, int last)
 {  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(curve->widget));
-   int i,x0,x1,fy0,fy1;
-
-   x0  = GuiCurveX(curve, 0);
-   fy0 = GuiCurveY(curve, curve->fvalue[0]);
+   int i,x0,x1,fy0;
 
    gdk_cairo_set_source_color(cr, Closure->curveColor);
    cairo_set_line_width(cr, 1.0);
 
-   /* Draw the curve */
+   /* Draw integer bar curve */
 
-   for(i=1; i<=last; i++)
-   {  x1  = GuiCurveX(curve, i);
-
-      if(curve->enable & DRAW_ICURVE)
-      {  int iy  = GuiCurveY(curve, curve->ivalue[i]);
-
-	 if(curve->ivalue[i] > 0)
-	 {  gdk_cairo_set_source_color(cr, Closure->barColor);
-	    cairo_rectangle(cr, x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomY-iy);
-            cairo_fill(cr);
-	 }
-      }
-
-      if(curve->enable & DRAW_LCURVE)
-      {  int iy  = GuiCurveLogY(curve, curve->lvalue[i]);
-
-	 if(curve->lvalue[i] > 0)
-         {  gdk_cairo_set_source_color(cr, Closure->logColor);
-            cairo_rectangle(cr, x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomLY-iy);
+   if(curve->enable & DRAW_ICURVE)
+   {  gdk_cairo_set_source_color(cr, Closure->barColor);
+      x0 = GuiCurveX(curve, 0);
+      for(i=1; i<=last; i++)
+      {  x1 = GuiCurveX(curve, i);
+         int iy = GuiCurveY(curve, curve->ivalue[i]);
+         if(curve->ivalue[i] > 0)
+         {  cairo_rectangle(cr, x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomY-iy);
             cairo_fill(cr);
          }
+         x0 = x1;
       }
+   }
 
-      if(curve->enable & DRAW_FCURVE && curve->fvalue[i] >= 0)
-      {  fy1 = GuiCurveY(curve, curve->fvalue[i]);
+   /* Draw logarithmic integer curve */
 
-	 if(x0 < x1)
-         {  gdk_cairo_set_source_color(cr, Closure->curveColor);
-            cairo_move_to(cr, x0, fy0);
-            cairo_line_to(cr, x1, fy1);
-            cairo_stroke(cr);
-	    fy0 = fy1;
-	 }
+   if(curve->enable & DRAW_LCURVE)
+   {  x0 = GuiCurveX(curve, 0);
+      for(i=1; i<=last; i++)
+      {  gdk_cairo_set_source_color(cr, Closure->logColor);
+         x1 = GuiCurveX(curve, i);
+         int iy = GuiCurveLogY(curve, curve->lvalue[i]);
+
+         if(curve->lvalue[i] > 0)
+         {  cairo_rectangle(cr, x0, iy, x0==x1 ? 1 : x1-x0, curve->bottomLY-iy);
+            cairo_fill(cr);
+         }
+         x0 = x1;
       }
+   }
 
-      x0 = x1;
+   /* Draw regular (floating point) curve */
+
+   if(curve->enable & DRAW_FCURVE)
+   {  x0 = GuiCurveX(curve, 0);
+      fy0 = GuiCurveY(curve, curve->fvalue[0]);
+      gdk_cairo_set_source_color(cr, Closure->curveColor);
+      cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+      cairo_move_to(cr, x0, fy0);
+      for(i=1; i<=last; i++)
+      {  x1 = GuiCurveX(curve, i);
+         if(x0 < x1 && curve->fvalue[i] >= 0)
+         {  cairo_line_to(cr, x1, GuiCurveY(curve, curve->fvalue[i]));
+            x0 = x1;
+         }
+      }
+      cairo_stroke(cr);
    }
 }
 #endif /* WITH_GUI_YES */

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -1533,7 +1533,7 @@ typedef struct _Spiral
    int diameter;
    int segmentClipping;
    int cursorPos;
-   GdkColor *colorUnderCursor;
+   gint lastRenderedCursorPos; /* use with atomic operations */
 } Spiral;
 
 #ifdef WITH_GUI_YES

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -413,7 +413,7 @@ typedef struct _GlobalClosure
    /*** Widgets for the linear reading/scanning action */
 
    GtkWidget *readLinearHeadline;
-   GtkWidget *readLinearDrawingArea;
+   GtkWidget *readLinearCurveArea;
    struct _Curve  *readLinearCurve;
    struct _Spiral *readLinearSpiral;
    GtkWidget *readLinearNotebook;

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -692,8 +692,8 @@ int  GuiCurveX(Curve*, gdouble);
 int  GuiCurveY(Curve*, gdouble);
 int  GuiCurveLogY(Curve*, gdouble);
 
-void GuiRedrawAxes(Curve*);
-void GuiRedrawCurve(Curve*, int);
+void GuiRedrawAxes(cairo_t *cr, Curve*);
+void GuiRedrawCurve(cairo_t *cr, Curve*, int);
 #endif
 
 /***
@@ -1542,8 +1542,8 @@ void GuiSetSpiralWidget(Spiral*, GtkWidget*);
 void GuiFreeSpiral(Spiral*);
 
 void GuiFillSpiral(Spiral*, GdkColor*);
-void GuiDrawSpiral(Spiral*);
-void GuiDrawSpiralLabel(Spiral*, PangoLayout*, char*, GdkColor*, int, int);
+void GuiDrawSpiral(cairo_t *cr, Spiral*);
+void GuiDrawSpiralLabel(cairo_t *cr, Spiral*, PangoLayout*, char*, GdkColor*, int, int);
 void GuiChangeSpiralCursor(Spiral*, int);
 void GuiMoveSpiralCursor(Spiral*, int);
 void GuiSetSpiralSegmentColor(Spiral*, GdkColor*, GdkColor*, int);

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -1543,10 +1543,10 @@ void GuiFreeSpiral(Spiral*);
 
 void GuiFillSpiral(Spiral*, GdkColor*);
 void GuiDrawSpiral(Spiral*);
-void GuiDrawSpiralSegment(Spiral*, GdkColor*, GdkColor*, int);
 void GuiDrawSpiralLabel(Spiral*, PangoLayout*, char*, GdkColor*, int, int);
 void GuiChangeSpiralCursor(Spiral*, int);
 void GuiMoveSpiralCursor(Spiral*, int);
+void GuiSetSpiralSegmentColor(Spiral*, GdkColor*, GdkColor*, int);
 #else
 #define GuiChangeSpiralCursor(a, b)
 #define GuiFreeSpiral(s)

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -393,7 +393,7 @@ typedef struct _GlobalClosure
 
    /*** Common stuff for drawing curves and spirals */
 
-   GdkGC     *drawGC;
+   gboolean  colors_initialized;
    GdkColor  *background,*foreground,*grid;
    GdkColor  *redText;
    char      *redMarkup;

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -1529,7 +1529,7 @@ typedef struct _Spiral
    int segmentCount;
    double *segmentPos;
    GdkColor **segmentColor;
-   GdkColor *outline;
+   GdkColor **segmentOutline;
    int diameter;
    int segmentClipping;
    int cursorPos;
@@ -1543,7 +1543,7 @@ void GuiFreeSpiral(Spiral*);
 
 void GuiFillSpiral(Spiral*, GdkColor*);
 void GuiDrawSpiral(Spiral*);
-void GuiDrawSpiralSegment(Spiral*, GdkColor*, int);
+void GuiDrawSpiralSegment(Spiral*, GdkColor*, GdkColor*, int);
 void GuiDrawSpiralLabel(Spiral*, PangoLayout*, char*, GdkColor*, int, int);
 void GuiChangeSpiralCursor(Spiral*, int);
 void GuiMoveSpiralCursor(Spiral*, int);

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -1522,7 +1522,7 @@ void EndIterativeSmartLEC(void*);
  ***/
 
 typedef struct _Spiral
-{  GdkDrawable *drawable;
+{  GtkWidget *widget;
    int mx, my;
    int startRadius;
    int segmentSize;

--- a/src/menubar.c
+++ b/src/menubar.c
@@ -363,7 +363,7 @@ static void file_select_cb(GtkWidget *widget, gpointer data)
                                               _("_Open"), GTK_RESPONSE_ACCEPT,
                                               NULL);
          gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog),
-                                       gtk_entry_get_text(GTK_ENTRY(Closure->imageEntry)));
+                                       gtk_entry_get_text(GTK_ENTRY(Closure->eccEntry)));
          if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
          {  g_free(Closure->imageName);
             Closure->eccName = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));

--- a/src/raw-editor.c
+++ b/src/raw-editor.c
@@ -547,44 +547,47 @@ static void render_sector(raw_editor_context *rec)
    int i,j,w,h,x,y;
 
    if(!d) return;
+   cairo_t *cr = gdk_cairo_create(d);
 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC,Closure->background);
-   gdk_draw_rectangle(d, Closure->drawGC, TRUE, 0, 0, rec->daWidth, rec->daHeight);
+   gdk_cairo_set_source_color(cr, Closure->background);
+   cairo_rectangle(cr, 0, 0, rec->daWidth, rec->daHeight);
+   cairo_fill(cr);
 
    idx = 12;
    for(j=0,y=0; j<P_VECTOR_SIZE; j++, y+=rec->charHeight)
    {  for(i=0,x=0; i<N_P_VECTORS; i++, x+=rec->charWidth)
       {  char byte[3];
 
-	 if(rec->tags[idx])
-	 {  gdk_gc_set_rgb_fg_color(Closure->drawGC,Closure->curveColor);
-	    gdk_draw_rectangle(d, Closure->drawGC, TRUE, x, y, 
-			       rec->charWidth, rec->charHeight);
-	 }
-	 else if(rec->rb->byteState[idx])
-	 {  if(rec->rb->byteState[idx] & (P1_CPOS | Q1_CPOS))
-	    {  gdk_gc_set_rgb_fg_color(Closure->drawGC,Closure->yellowSector);
-	       gdk_draw_rectangle(d, Closure->drawGC, TRUE, x, y, 
-				  rec->charWidth, rec->charHeight);
-	    } 
-	    else if(rec->rb->byteState[idx] & (P1_ERROR | Q1_ERROR))
-	    {  gdk_gc_set_rgb_fg_color(Closure->drawGC,Closure->greenText);
-	       gdk_draw_rectangle(d, Closure->drawGC, TRUE, x, y, 
-				  rec->charWidth, rec->charHeight);
-	    }
-	    else 
-	    {  gdk_gc_set_rgb_fg_color(Closure->drawGC,Closure->redText);
-	       gdk_draw_rectangle(d, Closure->drawGC, TRUE, x, y,
-				  rec->charWidth, rec->charHeight);
-	    }
-	 }
+         if(rec->tags[idx])
+         {  gdk_cairo_set_source_color(cr, Closure->curveColor);
+            cairo_rectangle(cr, x, y, rec->charWidth, rec->charHeight);
+            cairo_fill(cr);
+         }
+         else if(rec->rb->byteState[idx])
+         {  if(rec->rb->byteState[idx] & (P1_CPOS | Q1_CPOS))
+            {  gdk_cairo_set_source_color(cr, Closure->yellowSector);
+               cairo_rectangle(cr, x, y, rec->charWidth, rec->charHeight);
+               cairo_fill(cr);
+            }
+            else if(rec->rb->byteState[idx] & (P1_ERROR | Q1_ERROR))
+            {  gdk_cairo_set_source_color(cr, Closure->greenText);
+               cairo_rectangle(cr, x, y, rec->charWidth, rec->charHeight);
+               cairo_fill(cr);
+            }
+            else
+            {  gdk_cairo_set_source_color(cr, Closure->redText);
+               cairo_rectangle(cr, x, y, rec->charWidth, rec->charHeight);
+               cairo_fill(cr);
+            }
+         }
 
-         gdk_gc_set_rgb_fg_color(Closure->drawGC,Closure->foreground);
+         gdk_cairo_set_source_color(cr, Closure->foreground);
 
-	 sprintf(byte, "%c", canprint(buf[idx]) ? buf[idx] : '.');
-	 idx++;
-	 GuiSetText(rec->layout, byte, &w, &h);
-	 gdk_draw_layout(d, Closure->drawGC, x, y, rec->layout);
+         sprintf(byte, "%c", canprint(buf[idx]) ? buf[idx] : '.');
+         idx++;
+         GuiSetText(rec->layout, byte, &w, &h);
+         cairo_move_to(cr, x, y);
+         pango_cairo_show_layout(cr, rec->layout);
       }
    }
 }

--- a/src/raw-editor.c
+++ b/src/raw-editor.c
@@ -313,7 +313,7 @@ static void file_select_cb(GtkWidget *widget, gpointer data)
          memcpy(rec->undoRing[0], rec->rb->rawBuf[0], rec->rb->sampleSize);
          calculate_failures(rec);
          evaluate_vectors(rec);
-         render_sector(rec);
+         gtk_widget_queue_draw(GTK_WIDGET(rec->window));
          GuiSetLabelText(rec->rightLabel, _("%s loaded, LBA %" PRId64 ", %d samples."),
                          rec->filepath, rec->rb->lba, rec->rb->samplesRead);
       }
@@ -421,7 +421,7 @@ static void buffer_io_cb(GtkWidget *widget, gpointer data)
 
                calculate_failures(rec);
                evaluate_vectors(rec);
-               render_sector(rec);
+               gtk_widget_queue_draw(GTK_WIDGET(rec->window));
                undo_remember(rec);
 
                GuiSetLabelText(rec->rightLabel, _("Buffer loaded from %s."), path);
@@ -680,7 +680,7 @@ static gboolean button_cb(GtkWidget *widget, GdkEventButton *event, gpointer dat
 	 {  if(type=='P') SetPVector(rb->recovered, vector, v);
 	    else          SetQVector(rb->recovered, vector, v);
 	    evaluate_vectors(rec);
-	    render_sector(rec);
+	    gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	    undo_remember(rec);
 	    GuiSetLabelText(rec->rightLabel, 
 	       _("%c Vector %d corrected (%d erasures)."), type, v, e_scratch);
@@ -715,7 +715,7 @@ static gboolean button_cb(GtkWidget *widget, GdkEventButton *event, gpointer dat
 	 i = (last+1)%rb->pn[v];
 	 SetPVector(rb->recovered, rb->pList[v][i], v);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 GuiSetLabelText(rec->rightLabel, 
 		      _("Exchanged P vector %d with version %d (of %d)."),
 		      v, i+1, rb->pn[v]);
@@ -751,7 +751,7 @@ static gboolean button_cb(GtkWidget *widget, GdkEventButton *event, gpointer dat
 	 i = (last+1)%rb->qn[v];
 	 SetQVector(rb->recovered, rb->qList[v][i], v);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 GuiSetLabelText(rec->rightLabel, 
 		      _("Exchanged Q vector %d with version %d (of %d)."),
 		      v, i+1, rb->qn[v]);
@@ -766,7 +766,7 @@ static gboolean button_cb(GtkWidget *widget, GdkEventButton *event, gpointer dat
       {  int bytepos = 12 + mouse_x/rec->charWidth + N_P_VECTORS*(mouse_y/rec->charHeight);
 
 	 rec->tags[bytepos] ^= 1;
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
       }
 	 break;
@@ -812,7 +812,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 	 rec->sectorChanged = FALSE;
 	 memcpy(rec->rb->recovered, rec->rbInfo[rec->currentSample].rawSector, rec->rb->sampleSize);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 GuiSetLabelText(rec->rightLabel, _("Showing sample %d (of %d)."), 
 		      rec->currentSample, rec->rb->samplesRead);
@@ -825,7 +825,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 	 rec->sectorChanged = FALSE;
 	 memcpy(rec->rb->recovered, rec->rbInfo[rec->currentSample].rawSector, rec->rb->sampleSize);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 GuiSetLabelText(rec->rightLabel, _("Showing sample %d (of %d)."), 
 		      rec->currentSample, rec->rb->samplesRead);
@@ -833,7 +833,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 
       case ACTION_UNTAG:
 	 memset(rec->tags, 0, 2352);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 break;
 
@@ -848,7 +848,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 	       if(byte != rec->rb->rawBuf[j][i])
 		  rec->tags[i] = 1;
 	 }
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 break;
       }
@@ -856,13 +856,13 @@ static void action_cb(GtkWidget *widget, gpointer data)
       case ACTION_UNDO:
 	 undo(rec);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 break;
 
       case ACTION_REDO:
 	 redo(rec);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 break;
 
       case ACTION_SORT_BY_P:
@@ -871,7 +871,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 	 rec->currentSample = 0;
 	 memcpy(rec->rb->recovered, rec->rbInfo[rec->currentSample].rawSector, rec->rb->sampleSize);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 GuiSetLabelText(rec->rightLabel, _("Sector with lowest P failures selected."));
 	 break;
@@ -881,7 +881,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 	 rec->currentSample = 0;
 	 memcpy(rec->rb->recovered, rec->rbInfo[rec->currentSample].rawSector, rec->rb->sampleSize);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 GuiSetLabelText(rec->rightLabel, _("Sector with lowest Q failures selected."));
 	 break;
@@ -892,7 +892,7 @@ static void action_cb(GtkWidget *widget, gpointer data)
 	    rec->smartLECHandle = PrepareIterativeSmartLEC(rec->rb);
 	 SmartLECIteration(rec->smartLECHandle, message);
 	 evaluate_vectors(rec);
-	 render_sector(rec);
+	 gtk_widget_queue_draw(GTK_WIDGET(rec->window));
 	 undo_remember(rec);
 	 GuiSetLabelText(rec->rightLabel, _("Smart L-EC: %s"), message);
 	 break;

--- a/src/raw-editor.c
+++ b/src/raw-editor.c
@@ -106,7 +106,7 @@ typedef struct _raw_editor_context
 } raw_editor_context;
 
 static void evaluate_vectors(raw_editor_context*);
-static void render_sector(raw_editor_context*);
+static void render_sector(cairo_t *cr, raw_editor_context*);
 
 static raw_editor_context* create_raw_editor_context()
 {  raw_editor_context *rec = Closure->rawEditorContext;
@@ -540,14 +540,13 @@ static void evaluate_vectors(raw_editor_context *rec)
 
 /* Render the sector */
 
-static void render_sector(raw_editor_context *rec)
+static void render_sector(cairo_t *cr, raw_editor_context *rec)
 {  GdkWindow *d = gtk_widget_get_window(rec->drawingArea);
    unsigned char *buf = rec->rb->recovered;
    int idx=0;
    int i,j,w,h,x,y;
 
    if(!d) return;
-   cairo_t *cr = gdk_cairo_create(d);
 
    gdk_cairo_set_source_color(cr, Closure->background);
    cairo_rectangle(cr, 0, 0, rec->daWidth, rec->daHeight);
@@ -605,8 +604,10 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
    if(event->count) /* Exposure compression */
      return TRUE;
 
+   cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+
    evaluate_vectors(rec);
-   render_sector(rec);
+   render_sector(cr, rec);
 
    return TRUE;
 }

--- a/src/read-adaptive-window.c
+++ b/src/read-adaptive-window.c
@@ -61,9 +61,8 @@ static int draw_text(cairo_t *cr, PangoLayout *l, char *text, int x, int y, GdkC
    return h;
 }
 
-static void redraw_labels(GtkWidget *widget, int erase_mask)
-{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(Closure->readAdaptiveDrawingArea));
-   char buf[256];
+static void redraw_labels(cairo_t *cr, GtkWidget *widget, int erase_mask)
+{  char buf[256];
    int x,y,w,h;
 
    /* Draw the labels */
@@ -161,15 +160,15 @@ static void update_geometry(GtkWidget *widget)
 /* Expose event handler */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
    GuiSetSpiralWidget(Closure->readAdaptiveSpiral, widget);
   
    if(event->count) /* Exposure compression */
      return TRUE;
 
    update_geometry(widget);
-   redraw_labels(widget, ~0);
-   GuiDrawSpiral(Closure->readAdaptiveSpiral);
+   redraw_labels(cr, widget, ~0);
+   GuiDrawSpiral(cr, Closure->readAdaptiveSpiral);
 
    return TRUE;
 }

--- a/src/read-adaptive-window.c
+++ b/src/read-adaptive-window.c
@@ -182,7 +182,7 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
 }
 
 /*
- * Clip the spiral. Simply remove the clipping elements to avoid flicker.
+ * Clip the spiral.
  */
 
 static gboolean clip_idle_func(gpointer data)
@@ -190,22 +190,19 @@ static gboolean clip_idle_func(gpointer data)
    int i;
 
    if(spiral->segmentClipping < spiral->segmentCount)
-   {  GdkColor *outline = spiral->outline;
-      int clipping = spiral->segmentClipping;
+   {  int clipping = spiral->segmentClipping;
 
-      spiral->outline = Closure->background;
       spiral->segmentClipping = spiral->segmentCount;
    
       for(i=clipping; i < spiral->segmentCount; i++)
-	GuiDrawSpiralSegment(spiral, Closure->background, i);
+	GuiDrawSpiralSegment(spiral, Closure->background, Closure->background, i);
 
-      spiral->outline = outline;
       spiral->segmentClipping = clipping;
 
       /* Now redraw the last turn */
 
       for(i=ADAPTIVE_READ_SPIRAL_SIZE-300; i<=clipping; i++)
-	GuiDrawSpiralSegment(spiral, Closure->background, i);
+	GuiDrawSpiralSegment(spiral, Closure->background, 0, i);
    }   
 
    return FALSE;
@@ -233,6 +230,7 @@ static gboolean segment_idle_func(gpointer data)
    segment-=100;
    GuiDrawSpiralSegment(Closure->readAdaptiveSpiral,
 			Closure->readAdaptiveSpiral->segmentColor[segment],
+			0,
 			segment);
 
    return FALSE;
@@ -255,8 +253,8 @@ static gboolean remove_fill_idle_func(gpointer data)
    int i;
 
    for(i=0; i<spiral->segmentCount; i++)
-     if(spiral->segmentColor[i] == Closure->whiteSector)
-       GuiDrawSpiralSegment(spiral, Closure->background, i);
+      if(spiral->segmentColor[i] == Closure->whiteSector)
+         GuiDrawSpiralSegment(spiral, Closure->background, 0, i);
 
    return FALSE;
 }

--- a/src/read-adaptive-window.c
+++ b/src/read-adaptive-window.c
@@ -150,11 +150,6 @@ static void redraw_labels(GtkWidget *widget, int erase_mask)
    }
 }
 
-static void redraw_spiral(GtkWidget *widget)
-{
-   GuiDrawSpiral(Closure->readAdaptiveSpiral);
-}
-
 /* Calculate the geometry of the spiral */
 
 static void update_geometry(GtkWidget *widget)
@@ -176,7 +171,7 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
 
    update_geometry(widget);
    redraw_labels(widget, ~0);
-   redraw_spiral(widget);
+   GuiDrawSpiral(Closure->readAdaptiveSpiral);
 
    return TRUE;
 }
@@ -223,7 +218,7 @@ void GuiClipReadAdaptiveSpiral(int segments)
 
 static gboolean segment_idle_func(gpointer data)
 {
-   GuiDrawSpiral(Closure->readAdaptiveSpiral);
+   gtk_widget_queue_draw(Closure->readAdaptiveDrawingArea);
    return FALSE;
 }
 
@@ -258,9 +253,8 @@ void GuiRemoveFillMarkers()
  ***/
 
 static gboolean label_redraw_idle_func(gpointer data)
-{  int erase_mask = GPOINTER_TO_INT(data);
-
-   redraw_labels(Closure->readAdaptiveDrawingArea, erase_mask);
+{
+   gtk_widget_queue_draw(Closure->readAdaptiveDrawingArea);
 
    return FALSE;
 }
@@ -334,8 +328,7 @@ void GuiResetAdaptiveReadWindow()
       rect.width  = a.width;
       rect.height = a.height;
 
-      gdk_window_clear(gtk_widget_get_window(Closure->readAdaptiveDrawingArea));
-      gdk_window_invalidate_rect(gtk_widget_get_window(Closure->readAdaptiveDrawingArea), &rect, FALSE);
+      gtk_widget_queue_draw(Closure->readAdaptiveDrawingArea);
    }
 }
 

--- a/src/read-adaptive-window.c
+++ b/src/read-adaptive-window.c
@@ -217,31 +217,20 @@ void GuiClipReadAdaptiveSpiral(int segments)
 
 /*
  * Change the segment color.
- * Segment numbers are passed with an offset of 100,
- * since another routine is occasionally doing an
- * g_idle_remove_by_data(GINT_TO_POINTER(REDRAW_PROGRESS)),
- * with REDRAW_PROGRESS being 4 which would make segment 4 fail to redraw.
- * One of the many places where the Gtk+ API is not well thought out.
+ * We can't ask for a redraw when not an the main thread, but can set an idle
+ * function to do so.
  */
 
 static gboolean segment_idle_func(gpointer data)
-{  int segment = GPOINTER_TO_INT(data);
-  
-   segment-=100;
-   GuiDrawSpiralSegment(Closure->readAdaptiveSpiral,
-			Closure->readAdaptiveSpiral->segmentColor[segment],
-			0,
-			segment);
-
+{
+   GuiDrawSpiral(Closure->readAdaptiveSpiral);
    return FALSE;
 }
 
 void GuiChangeSegmentColor(GdkColor *color, int segment)
 {  
    Closure->readAdaptiveSpiral->segmentColor[segment] = color;
-   if(Closure->readAdaptiveSpiral->cursorPos == segment)
-        Closure->readAdaptiveSpiral->colorUnderCursor = color;
-   else g_idle_add(segment_idle_func, GINT_TO_POINTER(100+segment));
+   g_idle_add(segment_idle_func, 0);
 }
 
 /*

--- a/src/read-adaptive-window.c
+++ b/src/read-adaptive-window.c
@@ -195,14 +195,14 @@ static gboolean clip_idle_func(gpointer data)
       spiral->segmentClipping = spiral->segmentCount;
    
       for(i=clipping; i < spiral->segmentCount; i++)
-	GuiDrawSpiralSegment(spiral, Closure->background, Closure->background, i);
+	GuiSetSpiralSegmentColor(spiral, Closure->background, Closure->background, i);
 
       spiral->segmentClipping = clipping;
 
       /* Now redraw the last turn */
 
       for(i=ADAPTIVE_READ_SPIRAL_SIZE-300; i<=clipping; i++)
-	GuiDrawSpiralSegment(spiral, Closure->background, 0, i);
+	GuiSetSpiralSegmentColor(spiral, Closure->background, 0, i);
    }   
 
    return FALSE;
@@ -243,7 +243,7 @@ static gboolean remove_fill_idle_func(gpointer data)
 
    for(i=0; i<spiral->segmentCount; i++)
       if(spiral->segmentColor[i] == Closure->whiteSector)
-         GuiDrawSpiralSegment(spiral, Closure->background, 0, i);
+         GuiSetSpiralSegmentColor(spiral, Closure->background, 0, i);
 
    return FALSE;
 }

--- a/src/read-adaptive-window.c
+++ b/src/read-adaptive-window.c
@@ -39,48 +39,40 @@ static GdkColor *footer_color;
 #define REDRAW_PROGRESS   1<<2
 #define REDRAW_ERRORMSG   1<<3
 
-static int draw_text(GdkDrawable *d, PangoLayout *l, char *text, int x, int y, GdkColor *color, int redraw)
-{  static GdkPixmap *pixmap;
-   static int pixmap_width, pixmap_height;
-   int w,h,pw;
-   int erase_to = Closure->readAdaptiveSpiral->mx - Closure->readAdaptiveSpiral->diameter/2;
+static int draw_text(cairo_t *cr, PangoLayout *l, char *text, int x, int y, GdkColor *color, int redraw)
+{  int w,h,pw;
+   int erase_to;
 
    GuiSetText(l, text, &w, &h);
 
-   pw = erase_to-x;
-   if(pw > pixmap_width || h > pixmap_height)
-   {  if(pixmap) g_object_unref(pixmap);
-     
-      pixmap = gdk_pixmap_new(d, pw, h, -1);
-      pixmap_width = pw;
-      pixmap_height = h;
-   }
+   if(redraw)
+   {  erase_to = Closure->readAdaptiveSpiral->mx - Closure->readAdaptiveSpiral->diameter/2;
+      pw = erase_to-x;
 
+      gdk_cairo_set_source_color(cr, Closure->background);
+      cairo_rectangle(cr, x, y, pw, h);
+      cairo_fill(cr);
 
-   if(redraw)  /* redraw using double buffering to prevent flicker */
-   {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->background);
-      gdk_draw_rectangle(pixmap, Closure->drawGC, TRUE, 0, 0, pw, h);
-
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, color);
-      gdk_draw_layout(pixmap, Closure->drawGC, 0, 0, l);
-      gdk_draw_drawable(d, Closure->drawGC, pixmap, 0, 0, x, y, pw, h);
+      gdk_cairo_set_source_color(cr, color);
+      cairo_move_to(cr, x, y);
+      pango_cairo_show_layout(cr, l);
    }
 
    return h;
 }
 
 static void redraw_labels(GtkWidget *widget, int erase_mask)
-{  GdkDrawable *d = Closure->readAdaptiveDrawingArea->window;
+{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(Closure->readAdaptiveDrawingArea));
    char buf[256];
    int x,y,w,h;
 
    /* Draw the labels */
 
    x = 10; 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
+   gdk_cairo_set_source_color(cr, Closure->foreground);
 
    y = Closure->readAdaptiveSpiral->my - Closure->readAdaptiveSpiral->diameter/2;
-   h = draw_text(d, Closure->readLinearCurve->layout, 
+   h = draw_text(cr, Closure->readLinearCurve->layout,
 		 _("Adaptive reading:"), x, y, Closure->foreground, erase_mask & REDRAW_TITLE); 
 
    y += h+h/2;
@@ -92,36 +84,39 @@ static void redraw_labels(GtkWidget *widget, int erase_mask)
 
       if(c)                   /* split text into two lines */
       {  *c = 0;
-	 h = draw_text(d, Closure->readLinearCurve->layout, 
+	 h = draw_text(cr, Closure->readLinearCurve->layout,
 		       Closure->readAdaptiveSubtitle, x, y, Closure->foreground, 
 		       erase_mask & REDRAW_SUBTITLE); 
-	 h = draw_text(d, Closure->readLinearCurve->layout, 
+	 h = draw_text(cr, Closure->readLinearCurve->layout,
 			c+1, x, y+h, Closure->foreground, 
 			erase_mask & REDRAW_SUBTITLE); 
 	 *c = ' ';
       }
       else                    /* draw text in one line */
-      {  h = draw_text(d, Closure->readLinearCurve->layout, 
+      {  h = draw_text(cr, Closure->readLinearCurve->layout,
 		       Closure->readAdaptiveSubtitle, x, y, Closure->foreground, 
 		       erase_mask & REDRAW_SUBTITLE); 
       }
    }
 
    y += 4*h;
-   h = draw_text(d, Closure->readLinearCurve->layout, 
+   h = draw_text(cr, Closure->readLinearCurve->layout,
 		 _("Sectors processed"), x, y, Closure->foreground, erase_mask & REDRAW_TITLE); 
 
    y += h;
    snprintf(buf, 255, "  %s: %lld", _("readable"), readable);
-   h = draw_text(d, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground, erase_mask & REDRAW_PROGRESS); 
+   h = draw_text(cr, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground,
+                 erase_mask & REDRAW_PROGRESS);
 
    y += h;
    snprintf(buf, 255, "  %s: %lld", _("correctable"), correctable);
-   h = draw_text(d, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground, erase_mask & REDRAW_PROGRESS); 
+   h = draw_text(cr, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground,
+                 erase_mask & REDRAW_PROGRESS);
 
    y += h;
    snprintf(buf, 255, "  %s: %lld", _("missing"), missing);
-   h = draw_text(d, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground, erase_mask & REDRAW_PROGRESS); 
+   h = draw_text(cr, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground,
+                 erase_mask & REDRAW_PROGRESS);
 
    if(min_required > 0 && readable > 0)
    {  int percent = round(((1000*readable)/(readable+correctable+missing)));
@@ -133,20 +128,23 @@ static void redraw_labels(GtkWidget *widget, int erase_mask)
       snprintf(buf, 255, _("Readable: %d.%d%% / %d.%d%% required"), 
 	       percent/10, percent%10,
 	       min_required/10, min_required%10);
-      h = draw_text(d, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground, erase_mask & REDRAW_PROGRESS); 
+      h = draw_text(cr, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground,
+                    erase_mask & REDRAW_PROGRESS);
    }
 
    y += h;
    snprintf(buf, 255, _("Total recoverable: %d.%d%%"), percent/10, percent%10);
-   h = draw_text(d, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground, erase_mask & REDRAW_PROGRESS); 
+   h = draw_text(cr, Closure->readLinearCurve->layout, buf, x, y, Closure->foreground,
+                 erase_mask & REDRAW_PROGRESS);
 
 
    if(Closure->readAdaptiveErrorMsg && erase_mask & REDRAW_ERRORMSG)
-   {  gdk_gc_set_rgb_fg_color(Closure->drawGC, footer_color);
+   {  gdk_cairo_set_source_color(cr, footer_color);
       
       GuiSetText(Closure->readLinearCurve->layout, Closure->readAdaptiveErrorMsg, &w, &h);
       y = Closure->readAdaptiveSpiral->my + Closure->readAdaptiveSpiral->diameter/2 - h;
-      gdk_draw_layout(d, Closure->drawGC, x, y, Closure->readLinearCurve->layout);
+      cairo_move_to(cr, x, y);
+      pango_cairo_show_layout(cr, Closure->readLinearCurve->layout);
    }
 }
 

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -47,9 +47,7 @@ static void update_geometry(void);
 
 static gboolean max_speed_idle_func(gpointer data)
 {  
-   gdk_window_clear(gtk_widget_get_window(Closure->readLinearCurveArea));
-   update_geometry();
-   redraw_curve();
+   gtk_widget_queue_draw(Closure->readLinearCurveArea);
 
    return FALSE;
 }
@@ -203,7 +201,7 @@ void GuiAddCurveValues(void *rc_ptr, int percent, int color, int c2)
 
 static gboolean curve_mark_idle_func(gpointer data)
 {
-   GuiDrawSpiral(Closure->readLinearSpiral);
+   gtk_widget_queue_draw(Closure->readLinearSpiral->widget);
 
    return FALSE;
 }
@@ -328,29 +326,20 @@ void GuiResetLinearReadWindow()
 
    GuiZeroCurve(Closure->readLinearCurve);
    GuiFillSpiral(Closure->readLinearSpiral, Closure->background);
-   GuiDrawSpiral(Closure->readLinearSpiral);
+   if (Closure->readLinearSpiral->widget)
+      gtk_widget_queue_draw(Closure->readLinearSpiral->widget);
 }
 
 /*
- * Re-layout and redraw the read window while it is in use.
+ * Re-layout and redraw the curve drawing area while it is in use.
  * Required to add the information that CRC data is available,
  * since this happens when the the initial rendering of the window
  * contents have already been carried out.
  */
 
 static gboolean redraw_idle_func(gpointer data)
-{  GdkRectangle rect;
-   GdkWindow *window;
-   gint ignore;
-
-   /* Trigger an expose event for the drawing area. */
-
-   window = gtk_widget_get_parent_window(Closure->readLinearCurveArea);
-   if(window) 
-   {  gdk_window_get_geometry(window, &rect.x, &rect.y, &rect.width, &rect.height, &ignore);
-
-      gdk_window_invalidate_rect(window, &rect, TRUE); 
-   }
+{
+   gtk_widget_queue_draw(Closure->readLinearCurveArea);
 
    return FALSE;
 }

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -252,19 +252,17 @@ static void update_geometry(void)
 }
 
 static void redraw_spiral_labels(void)
-{  GdkWindow *d = gtk_widget_get_window(Closure->readLinearSpiral->widget);
+{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(Closure->readLinearSpiral->widget));
    int x,w,h;
    int pos = 1;
 
    /* Draw and label the spiral */
 
    x = 10;
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
    GuiSetText(Closure->readLinearCurve->layout, _("Medium state"), &w, &h);
-   gdk_draw_layout(d, Closure->drawGC, 
-		   x,
-		   Closure->readLinearCurve->topY - h - 5, 
-		   Closure->readLinearCurve->layout);
+   gdk_cairo_set_source_color(cr, Closure->curveColor);
+   cairo_move_to(cr, x, Closure->readLinearCurve->topY - h - 5);
+   pango_cairo_show_layout(cr, Closure->readLinearCurve->layout);
 
    if(Closure->additionalSpiralColor == 0)
      GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -116,11 +116,11 @@ static gboolean curve_idle_func(gpointer data)
 
    for(i=rc->lastSegment; i<ci->percent; i++)
      switch(Closure->readLinearCurve->ivalue[i])
-     {  case 0: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->blueSector, i); break;
-        case 1: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->greenSector, i); break;
-        case 2: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->redSector, i); break;
-        case 3: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->darkSector, i); break;
-        case 4: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->yellowSector, i); break;
+     {  case 0: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->blueSector, 0, i); break;
+        case 1: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->greenSector, 0, i); break;
+        case 2: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->redSector, 0, i); break;
+        case 3: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->darkSector, 0, i); break;
+        case 4: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->yellowSector, 0, i); break;
      }
 
    rc->lastSegment = ci->percent;

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -34,7 +34,7 @@
  *** Forward declarations
  ***/
 
-static void redraw_curve(void);
+static void redraw_curve(cairo_t *cr);
 static void update_geometry(void);
 
 /***
@@ -230,10 +230,10 @@ void GuiMarkExistingSectors(void)
  * Redraw the whole curve
  */
 
-static void redraw_curve(void)
+static void redraw_curve(cairo_t *cr)
 {
-   GuiRedrawAxes(Closure->readLinearCurve);
-   GuiRedrawCurve(Closure->readLinearCurve, 1000);
+   GuiRedrawAxes(cr, Closure->readLinearCurve);
+   GuiRedrawCurve(cr, Closure->readLinearCurve, 1000);
 }
 
 /* Calculate the geometry of the curve */
@@ -251,9 +251,8 @@ static void update_geometry(void)
 
 }
 
-static void redraw_spiral_labels(void)
-{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(Closure->readLinearSpiral->widget));
-   int x,w,h;
+static void redraw_spiral_labels(cairo_t *cr)
+{  int x,w,h;
    int pos = 1;
 
    /* Draw and label the spiral */
@@ -265,36 +264,37 @@ static void redraw_spiral_labels(void)
    pango_cairo_show_layout(cr, Closure->readLinearCurve->layout);
 
    if(Closure->additionalSpiralColor == 0)
-     GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,
+     GuiDrawSpiralLabel(cr, Closure->readLinearSpiral, Closure->readLinearCurve->layout,
 			_("Not touched this time"), Closure->curveColor, x, -1);
 
    if(Closure->additionalSpiralColor == 3)
-     GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,
+     GuiDrawSpiralLabel(cr, Closure->readLinearSpiral, Closure->readLinearCurve->layout,
 			_("Already present"), Closure->darkSector, x, -1);
 
-   GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,
+   GuiDrawSpiralLabel(cr, Closure->readLinearSpiral, Closure->readLinearCurve->layout,
 		      _("Successfully read"), Closure->greenSector, x, pos++);
 
    if(Closure->crcBuf && Closure->crcBuf->crcCached)
-     GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,
+     GuiDrawSpiralLabel(cr, Closure->readLinearSpiral, Closure->readLinearCurve->layout,
 			_("Sectors with CRC errors"), Closure->yellowSector, x, pos++);
 
-   GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,
+   GuiDrawSpiralLabel(cr, Closure->readLinearSpiral, Closure->readLinearCurve->layout,
 		      _("Unreadable / skipped"), Closure->redSector, x, pos++);
 
-   GuiDrawSpiral(Closure->readLinearSpiral);
+   GuiDrawSpiral(cr, Closure->readLinearSpiral);
 }
 
 static gboolean expose_curve_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
    update_geometry();
-   redraw_curve();
+   redraw_curve(cr);
 
    return TRUE;
 }
 
 static gboolean expose_spiral_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  GtkAllocation a = {0};
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   GtkAllocation a = {0};
    gtk_widget_get_allocation(widget, &a);
 
    GuiSetSpiralWidget(Closure->readLinearSpiral, widget);
@@ -309,7 +309,7 @@ static gboolean expose_spiral_cb(GtkWidget *widget, GdkEventExpose *event, gpoin
       Closure->readLinearSpiral->my = a.height/2 - h;
    }
 
-   redraw_spiral_labels();
+   redraw_spiral_labels(cr);
 
    return TRUE;
 }

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -47,7 +47,7 @@ static void update_geometry(void);
 
 static gboolean max_speed_idle_func(gpointer data)
 {  
-   gdk_window_clear(gtk_widget_get_window(Closure->readLinearDrawingArea));
+   gdk_window_clear(gtk_widget_get_window(Closure->readLinearCurveArea));
    update_geometry();
    redraw_curve();
 
@@ -143,7 +143,7 @@ static gboolean curve_idle_func(gpointer data)
    {  Closure->readLinearCurve->maxY = Closure->readLinearCurve->fvalue[ci->percent] + 1;
 
       update_geometry();
-      gdk_window_clear(gtk_widget_get_window(Closure->readLinearDrawingArea));
+      gdk_window_clear(gtk_widget_get_window(Closure->readLinearCurveArea));
       redraw_curve();
       rc->lastPlotted = ci->percent;
       rc->lastPlottedY = GuiCurveY(Closure->readLinearCurve, Closure->readLinearCurve->fvalue[ci->percent]); 
@@ -168,14 +168,14 @@ static gboolean curve_idle_func(gpointer data)
       if(Closure->readLinearCurve->lvalue[i])
       {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->logColor);
       
-	 gdk_draw_rectangle(Closure->readLinearDrawingArea->window,
+	 gdk_draw_rectangle(Closure->readLinearCurveArea->window,
 			    Closure->drawGC, TRUE,
 			    x0, l1,
 			    x0==x1 ? 1 : x1-x0, Closure->readLinearCurve->bottomLY-l1);
       }
       if(x0<x1)
       {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
-	 gdk_draw_line(Closure->readLinearDrawingArea->window,
+	 gdk_draw_line(Closure->readLinearCurveArea->window,
 		      Closure->drawGC,
 		      x0, y0, x1, y1);
 
@@ -276,30 +276,17 @@ void GuiMarkExistingSectors(void)
  * Redraw the whole curve
  */
 
-/* Calculate the geometry of the curve and spiral */
+static void redraw_curve(void)
+{
+   GuiRedrawAxes(Closure->readLinearCurve);
+   GuiRedrawCurve(Closure->readLinearCurve, 1000);
+}
+
+/* Calculate the geometry of the curve */
 
 static void update_geometry(void)
-{  GtkWidget *widget = Closure->readLinearDrawingArea;
-   GtkAllocation a = {0};
-   gtk_widget_get_allocation(widget, &a);
-
-   /* Curve geometry */ 
-
-   GuiUpdateCurveGeometry(Closure->readLinearCurve, "99x", 
-			  Closure->readLinearSpiral->diameter + 30);
-
-   /* Spiral center */
-
-   Closure->readLinearSpiral->mx = a.width - 15 - Closure->readLinearSpiral->diameter / 2;
-   Closure->readLinearSpiral->my = a.height / 2;
-
-   if(Closure->crcBuf && Closure->crcBuf->crcCached)
-   {  int w,h;
-
-      GuiSetText(Closure->readLinearCurve->layout, _("Sectors with CRC errors"), &w, &h);
-
-      Closure->readLinearSpiral->my -= h;
-   }
+{
+   GuiUpdateCurveGeometry(Closure->readLinearCurve, "99x", 10);
 
    /* Label positions in the foot line */
 
@@ -310,14 +297,14 @@ static void update_geometry(void)
 
 }
 
-static void redraw_curve(void)
-{  GdkWindow *d = gtk_widget_get_window(Closure->readLinearDrawingArea);
+static void redraw_spiral_labels(void)
+{  GdkWindow *d = gtk_widget_get_window(Closure->readLinearSpiral->widget);
    int x,w,h;
    int pos = 1;
 
    /* Draw and label the spiral */
 
-   x = Closure->readLinearCurve->rightX + 20;
+   x = 10;
    gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->curveColor);
    GuiSetText(Closure->readLinearCurve->layout, _("Medium state"), &w, &h);
    gdk_draw_layout(d, Closure->drawGC, 
@@ -344,22 +331,33 @@ static void redraw_curve(void)
 		      _("Unreadable / skipped"), Closure->redSector, x, pos++);
 
    GuiDrawSpiral(Closure->readLinearSpiral);
-
-   /* Redraw the curve */
-
-   GuiRedrawAxes(Closure->readLinearCurve);
-   GuiRedrawCurve(Closure->readLinearCurve, 1000);
 }
 
-static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  
-   GuiSetSpiralWidget(Closure->readLinearSpiral, widget);
-  
-   if(event->count) /* Exposure compression */
-     return TRUE;
-
+static gboolean expose_curve_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
+{
    update_geometry();
    redraw_curve();
+
+   return TRUE;
+}
+
+static gboolean expose_spiral_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
+{  GtkAllocation a = {0};
+   gtk_widget_get_allocation(widget, &a);
+
+   GuiSetSpiralWidget(Closure->readLinearSpiral, widget);
+
+   /* Override spiral center */
+   Closure->readLinearSpiral->mx = a.width - 15 - Closure->readLinearSpiral->diameter / 2;
+   if(Closure->crcBuf && Closure->crcBuf->crcCached)
+   {  int w,h;
+
+      GuiSetText(Closure->readLinearCurve->layout, _("Sectors with CRC errors"), &w, &h);
+
+      Closure->readLinearSpiral->my = a.height/2 - h;
+   }
+
+   redraw_spiral_labels();
 
    return TRUE;
 }
@@ -391,7 +389,7 @@ static gboolean redraw_idle_func(gpointer data)
 
    /* Trigger an expose event for the drawing area. */
 
-   window = gtk_widget_get_parent_window(Closure->readLinearDrawingArea);
+   window = gtk_widget_get_parent_window(Closure->readLinearCurveArea);
    if(window) 
    {  gdk_window_get_geometry(window, &rect.x, &rect.y, &rect.width, &rect.height, &ignore);
 
@@ -411,7 +409,7 @@ void GuiRedrawReadLinearWindow(void)
  ***/
 
 void GuiCreateLinearReadWindow(GtkWidget *parent)
-{  GtkWidget *sep,*ignore,*d_area,*notebook,*hbox;
+{  GtkWidget *sep,*ignore,*curve,*spiral,*notebook,*hbox;
 
    Closure->readLinearHeadline = gtk_label_new(NULL);
    gtk_misc_set_alignment(GTK_MISC(Closure->readLinearHeadline), 0.0, 0.0); 
@@ -425,9 +423,18 @@ void GuiCreateLinearReadWindow(GtkWidget *parent)
    sep = gtk_hseparator_new();
    gtk_box_pack_start(GTK_BOX(parent), sep, FALSE, FALSE, 0);
 
-   d_area = Closure->readLinearDrawingArea = gtk_drawing_area_new();
-   gtk_box_pack_start(GTK_BOX(parent), d_area, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT(d_area), "expose_event", G_CALLBACK(expose_cb), NULL);
+   hbox = gtk_hbox_new(FALSE, 0);
+   gtk_box_pack_start(GTK_BOX(parent), hbox, TRUE, TRUE, 0);
+
+   curve = Closure->readLinearCurveArea = gtk_drawing_area_new();
+   gtk_box_pack_start(GTK_BOX(hbox), curve, TRUE, TRUE, 0);
+   g_signal_connect(G_OBJECT(curve), "expose_event", G_CALLBACK(expose_curve_cb), NULL);
+
+   Closure->readLinearSpiral = GuiCreateSpiral(Closure->grid, Closure->background, 10, 5, 1000);
+   spiral = gtk_drawing_area_new();
+   gtk_widget_set_size_request(spiral, Closure->readLinearSpiral->diameter + 20, -1);
+   gtk_box_pack_start(GTK_BOX(hbox), spiral, FALSE, FALSE, 0);
+   g_signal_connect(G_OBJECT(spiral), "expose_event", G_CALLBACK(expose_spiral_cb), NULL);
 
    notebook = Closure->readLinearNotebook = gtk_notebook_new();
    gtk_notebook_set_show_tabs(GTK_NOTEBOOK(notebook), FALSE);
@@ -452,8 +459,7 @@ void GuiCreateLinearReadWindow(GtkWidget *parent)
    ignore = gtk_label_new("footer_tab");
    gtk_notebook_append_page(GTK_NOTEBOOK(notebook), Closure->readLinearFootline, ignore);
 
-   Closure->readLinearCurve  = GuiCreateCurve(d_area, _("Speed"), "%dx", 1000, CURVE_MEGABYTES);
+   Closure->readLinearCurve  = GuiCreateCurve(curve, _("Speed"), "%dx", 1000, CURVE_MEGABYTES);
    Closure->readLinearCurve->leftLogLabel = g_strdup(_("C2 errors"));
-   Closure->readLinearSpiral = GuiCreateSpiral(Closure->grid, Closure->background, 10, 5, 1000);
 }
 #endif /* WITH_GUI_YES */

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -260,8 +260,6 @@ void GuiMarkExistingSectors(void)
    x = Closure->readLinearCurve->rightX + 20;
    
    Closure->additionalSpiralColor = 3;
-   GuiDrawSpiralLabel(Closure->readLinearSpiral, Closure->readLinearCurve->layout,
-		      _("Already present"), Closure->darkSector, x, -1);
 
    for(i=0; i<1000; i++)
       if(Closure->readLinearSpiral->segmentColor[i] == Closure->greenSector)

--- a/src/read-linear-window.c
+++ b/src/read-linear-window.c
@@ -112,15 +112,15 @@ static gboolean curve_idle_func(gpointer data)
    gtk_label_set_text(GTK_LABEL(Closure->readLinearErrors), utf);
    g_free(utf);
 
-   /*** Draw the changed spiral segments */
+   /*** Update color of the changed spiral segments */
 
    for(i=rc->lastSegment; i<ci->percent; i++)
      switch(Closure->readLinearCurve->ivalue[i])
-     {  case 0: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->blueSector, 0, i); break;
-        case 1: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->greenSector, 0, i); break;
-        case 2: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->redSector, 0, i); break;
-        case 3: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->darkSector, 0, i); break;
-        case 4: GuiDrawSpiralSegment(Closure->readLinearSpiral, Closure->yellowSector, 0, i); break;
+     {  case 0: GuiSetSpiralSegmentColor(Closure->readLinearSpiral, Closure->blueSector, 0, i); break;
+        case 1: GuiSetSpiralSegmentColor(Closure->readLinearSpiral, Closure->greenSector, 0, i); break;
+        case 2: GuiSetSpiralSegmentColor(Closure->readLinearSpiral, Closure->redSector, 0, i); break;
+        case 3: GuiSetSpiralSegmentColor(Closure->readLinearSpiral, Closure->darkSector, 0, i); break;
+        case 4: GuiSetSpiralSegmentColor(Closure->readLinearSpiral, Closure->yellowSector, 0, i); break;
      }
 
    rc->lastSegment = ci->percent;

--- a/src/read-linear.h
+++ b/src/read-linear.h
@@ -88,7 +88,6 @@ typedef struct
    gint lastCopied;
    gint lastSegment;
    gint lastPlotted;
-   gint lastPlottedY;
    gint activeRenderers;
    GMutex *rendererMutex;
 

--- a/src/rs01-verify.c
+++ b/src/rs01-verify.c
@@ -56,7 +56,8 @@ void ResetRS01VerifyWindow(Method *self)
    wl->lastPercent = 0;
 
    GuiFillSpiral(wl->cmpSpiral, Closure->background);
-   GuiDrawSpiral(wl->cmpSpiral);
+   if (wl->cmpSpiral->widget)
+      gtk_widget_queue_draw(wl->cmpSpiral->widget);
 }
 
 /***

--- a/src/rs01-verify.c
+++ b/src/rs01-verify.c
@@ -78,7 +78,7 @@ static gboolean spiral_idle_func(gpointer data)
    int i;
 
    for(i=sii->from; i<=sii->to; i++)
-     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, i-1);
+     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, 0, i-1);
 
    g_free(sii);
    return FALSE;

--- a/src/rs01-verify.c
+++ b/src/rs01-verify.c
@@ -78,7 +78,7 @@ static gboolean spiral_idle_func(gpointer data)
    int i;
 
    for(i=sii->from; i<=sii->to; i++)
-     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, 0, i-1);
+     GuiSetSpiralSegmentColor(sii->cmpSpiral, sii->segColor, 0, i-1);
 
    g_free(sii);
    return FALSE;

--- a/src/rs01-verify.c
+++ b/src/rs01-verify.c
@@ -121,19 +121,19 @@ void RS01AddVerifyValues(Method *method, int percent,
  * Redraw whole spiral
  */
 
-static void redraw_spiral(RS01Widgets *wl)
+static void redraw_spiral(cairo_t *cr, RS01Widgets *wl)
 {  int x = wl->cmpSpiral->mx - wl->cmpSpiral->diameter/2 + 10;
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Good sectors"), Closure->greenSector, x, 1);
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Sectors with CRC errors"), Closure->yellowSector, x, 2);
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Missing sectors"), Closure->redSector, x, 3);
 
-   GuiDrawSpiral(wl->cmpSpiral);
+   GuiDrawSpiral(cr, wl->cmpSpiral);
 }
 
 /*
@@ -141,7 +141,8 @@ static void redraw_spiral(RS01Widgets *wl)
  */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  RS01Widgets *wl = (RS01Widgets*)data;
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   RS01Widgets *wl = (RS01Widgets*)data;
    GtkAllocation a = {0};
    gtk_widget_get_allocation(widget, &a);
    int w,h,size;
@@ -165,7 +166,7 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
 
    /* Redraw the spiral */
 
-   redraw_spiral(wl);
+   redraw_spiral(cr, wl);
 
    return TRUE;
 }

--- a/src/rs01-window.c
+++ b/src/rs01-window.c
@@ -268,10 +268,13 @@ static void redraw_curve(RS01Widgets *wl)
    /* Ecc capacity threshold line */
 
    y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->greenSector);
-   gdk_draw_line(gtk_widget_get_window(wl->fixCurve->widget),
-		 Closure->drawGC,
-		 wl->fixCurve->leftX-6, y, wl->fixCurve->rightX+6, y);
+
+   cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(wl->fixCurve->widget));
+   gdk_cairo_set_source_color(cr, Closure->greenSector);
+   cairo_set_line_width(cr, 1.0);
+   cairo_move_to(cr, wl->fixCurve->leftX-5.5, y+0.5);
+   cairo_line_to(cr, wl->fixCurve->rightX+5.5, y+0.5);
+   cairo_stroke(cr);
 }
 
 /*

--- a/src/rs01-window.c
+++ b/src/rs01-window.c
@@ -174,7 +174,7 @@ void CreateRS01EWindow(Method *method, GtkWidget *parent)
 static gboolean set_max_idle_func(gpointer data)
 {  RS01Widgets *wl = (RS01Widgets*)data;
 
-   redraw_curve(wl);
+   gtk_widget_queue_draw(wl->fixCurve->widget);
 
    return FALSE;
 }
@@ -304,9 +304,7 @@ void ResetRS01FixWindow(Method *method)
    RS01UpdateFixResults(wl, 0, 0);
 
    if(wl->fixCurve && wl->fixCurve->widget)
-   {  gdk_window_clear(gtk_widget_get_window(wl->fixCurve->widget));
-      redraw_curve(wl);
-   }
+      gtk_widget_queue_draw(wl->fixCurve->widget);
 
    wl->percent = 0;
    wl->lastPercent = 0;

--- a/src/rs01-window.c
+++ b/src/rs01-window.c
@@ -32,7 +32,7 @@
  *** Forward declarations
  ***/
 
-static void redraw_curve(RS01Widgets*);
+static void redraw_curve(cairo_t *cr, RS01Widgets*);
 static void update_geometry(RS01Widgets*);
 
 /* Protected widget access */
@@ -257,19 +257,18 @@ static void update_geometry(RS01Widgets *wl)
 			     TRUE, TRUE, wl->fixCurve->leftX, GTK_PACK_START);
 }
 
-static void redraw_curve(RS01Widgets *wl)
+static void redraw_curve(cairo_t *cr, RS01Widgets *wl)
 {  int y;
 
    /* Redraw the curve */
 
-   GuiRedrawAxes(wl->fixCurve);
-   GuiRedrawCurve(wl->fixCurve, wl->percent);
+   GuiRedrawAxes(cr, wl->fixCurve);
+   GuiRedrawCurve(cr, wl->fixCurve, wl->percent);
 
    /* Ecc capacity threshold line */
 
    y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
 
-   cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(wl->fixCurve->widget));
    gdk_cairo_set_source_color(cr, Closure->greenSector);
    cairo_set_line_width(cr, 1.0);
    cairo_move_to(cr, wl->fixCurve->leftX-5.5, y+0.5);
@@ -282,14 +281,15 @@ static void redraw_curve(RS01Widgets *wl)
  */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  RS01Widgets *wl = (RS01Widgets*)data; 
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   RS01Widgets *wl = (RS01Widgets*)data;
 
    if(event->count) /* Exposure compression */
    {  return TRUE;
    }
 
    update_geometry(wl);
-   redraw_curve(wl);
+   redraw_curve(cr, wl);
 
    return TRUE;
 }

--- a/src/rs01-window.c
+++ b/src/rs01-window.c
@@ -218,47 +218,8 @@ void RS01UpdateFixResults(RS01Widgets *wl, gint64 corrected, gint64 uncorrected)
 
 static gboolean curve_idle_func(gpointer data)
 {  RS01Widgets *wl = (RS01Widgets*)data;
-   gint x0 = GuiCurveX(wl->fixCurve, (double)wl->lastPercent);
-   gint x1 = GuiCurveX(wl->fixCurve, (double)wl->percent);
-   gint y = GuiCurveY(wl->fixCurve, wl->fixCurve->ivalue[wl->percent]);
-   gint i;
+   gtk_widget_queue_draw(wl->fixCurve->widget);
 
-   /*** Mark unused ecc values */
-
-   for(i=wl->lastPercent+1; i<wl->percent; i++)
-      wl->fixCurve->ivalue[i] = wl->fixCurve->ivalue[wl->percent];
-
-   /*** Resize the Y axes if error values exceeds current maximum */
-
-   if(wl->fixCurve->ivalue[wl->percent] > wl->fixCurve->maxY)
-   {  wl->fixCurve->maxY = wl->fixCurve->ivalue[wl->percent];
-      wl->fixCurve->maxY = wl->fixCurve->maxY - (wl->fixCurve->maxY % 5) + 5;
-
-      update_geometry(wl);
-      gdk_window_clear(gtk_widget_get_window(wl->fixCurve->widget));
-      redraw_curve(wl);
-      wl->lastPercent = wl->percent;
-
-      return FALSE;
-   }
-
-   /*** Draw the error value */
-
-   if(wl->fixCurve->ivalue[wl->percent] > 0)
-   {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->barColor);
-      gdk_draw_rectangle(wl->fixCurve->widget->window,
-			 Closure->drawGC, TRUE,
-			 x0, y, x0==x1 ? 1 : x1-x0, wl->fixCurve->bottomY-y);
-   }
-   wl->lastPercent = wl->percent;
-
-   /* Redraw the ecc capacity threshold line */
-
-   y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->greenSector);
-   gdk_draw_line(gtk_widget_get_window(wl->fixCurve->widget),
-		 Closure->drawGC,
-		 wl->fixCurve->leftX-6, y, wl->fixCurve->rightX+6, y);
    return FALSE;
 }
 

--- a/src/rs02-verify.c
+++ b/src/rs02-verify.c
@@ -81,7 +81,7 @@ static gboolean spiral_idle_func(gpointer data)
    int i;
 
    for(i=sii->from; i<=sii->to; i++)
-     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, i-1);
+     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, 0, i-1);
 
    g_free(sii);
    return FALSE;

--- a/src/rs02-verify.c
+++ b/src/rs02-verify.c
@@ -114,19 +114,19 @@ static void add_verify_values(Method *method, int percent,
  * Redraw whole spiral
  */
 
-static void redraw_spiral(RS02Widgets *wl)
+static void redraw_spiral(cairo_t *cr, RS02Widgets *wl)
 {  int x = wl->cmpSpiral->mx - wl->cmpSpiral->diameter/2 + 10;
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Good sectors"), Closure->greenSector, x, 1);
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Sectors with CRC errors"), Closure->yellowSector, x, 2);
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Missing sectors"), Closure->redSector, x, 3);
 
-   GuiDrawSpiral(wl->cmpSpiral);
+   GuiDrawSpiral(cr, wl->cmpSpiral);
 }
 
 /*
@@ -134,7 +134,8 @@ static void redraw_spiral(RS02Widgets *wl)
  */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  RS02Widgets *wl = (RS02Widgets*)data;
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   RS02Widgets *wl = (RS02Widgets*)data;
    GtkAllocation a = {0};
    gtk_widget_get_allocation(widget, &a);
    int w,h,size;
@@ -153,7 +154,7 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
    wl->cmpSpiral->my = (wl->cmpSpiral->diameter + a.height - size)/2;
 
    if(!event->count)      /* Exposure compression */
-     redraw_spiral(wl);   /* Redraw the spiral */
+     redraw_spiral(cr, wl);   /* Redraw the spiral */
 
    return TRUE;
 }

--- a/src/rs02-verify.c
+++ b/src/rs02-verify.c
@@ -59,7 +59,8 @@ void ResetRS02VerifyWindow(Method *self)
    wl->lastPercent = 0;
 
    GuiFillSpiral(wl->cmpSpiral, Closure->background);
-   GuiDrawSpiral(wl->cmpSpiral);
+   if (wl->cmpSpiral->widget)
+      gtk_widget_queue_draw(wl->cmpSpiral->widget);
 }
 
 /***

--- a/src/rs02-verify.c
+++ b/src/rs02-verify.c
@@ -81,7 +81,7 @@ static gboolean spiral_idle_func(gpointer data)
    int i;
 
    for(i=sii->from; i<=sii->to; i++)
-     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, 0, i-1);
+     GuiSetSpiralSegmentColor(sii->cmpSpiral, sii->segColor, 0, i-1);
 
    g_free(sii);
    return FALSE;

--- a/src/rs02-window.c
+++ b/src/rs02-window.c
@@ -111,7 +111,7 @@ void CreateRS02EncWindow(Method *method, GtkWidget *parent)
 static gboolean set_max_idle_func(gpointer data)
 {  RS02Widgets *wl = (RS02Widgets*)data;
 
-   redraw_curve(wl);
+   gtk_widget_queue_draw(wl->fixCurve->widget);
 
    return FALSE;
 }
@@ -239,9 +239,7 @@ void ResetRS02FixWindow(Method *method)
    RS02UpdateFixResults(wl, 0, 0);
 
    if(wl->fixCurve && wl->fixCurve->widget)
-   {  gdk_window_clear(gtk_widget_get_window(wl->fixCurve->widget));
-      redraw_curve(wl);
-   }
+      gtk_widget_queue_draw(wl->fixCurve->widget);
 
    wl->percent = 0;
    wl->lastPercent = 0;

--- a/src/rs02-window.c
+++ b/src/rs02-window.c
@@ -34,7 +34,7 @@ extern gint64 CurrentMediumSize(int);  /* from scsi-layer.h */
  *** Forward declarations
  ***/
 
-static void redraw_curve(RS02Widgets*);
+static void redraw_curve(cairo_t *cr, RS02Widgets*);
 static void update_geometry(RS02Widgets*);
 
 /***
@@ -197,19 +197,18 @@ static void update_geometry(RS02Widgets *wl)
 			     TRUE, TRUE, wl->fixCurve->leftX, GTK_PACK_START);
 }
 
-static void redraw_curve(RS02Widgets *wl)
+static void redraw_curve(cairo_t *cr, RS02Widgets *wl)
 {  int y;
 
    /* Redraw the curve */
 
-   GuiRedrawAxes(wl->fixCurve);
-   GuiRedrawCurve(wl->fixCurve, wl->percent);
+   GuiRedrawAxes(cr, wl->fixCurve);
+   GuiRedrawCurve(cr, wl->fixCurve, wl->percent);
 
    /* Ecc capacity threshold line */
 
    y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
 
-   cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(wl->fixCurve->widget));
    gdk_cairo_set_source_color(cr, Closure->greenSector);
    cairo_set_line_width(cr, 1.0);
    cairo_move_to(cr, wl->fixCurve->leftX-5.5, y+0.5);
@@ -222,13 +221,14 @@ static void redraw_curve(RS02Widgets *wl)
  */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  RS02Widgets *wl = (RS02Widgets*)data; 
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   RS02Widgets *wl = (RS02Widgets*)data;
 
    if(event->count) /* Exposure compression */
      return TRUE;
 
    update_geometry(wl);
-   redraw_curve(wl);
+   redraw_curve(cr, wl);
 
    return TRUE;
 }

--- a/src/rs02-window.c
+++ b/src/rs02-window.c
@@ -208,10 +208,13 @@ static void redraw_curve(RS02Widgets *wl)
    /* Ecc capacity threshold line */
 
    y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->greenSector);
-   gdk_draw_line(wl->fixCurve->widget->window,
-		 Closure->drawGC,
-		 wl->fixCurve->leftX-6, y, wl->fixCurve->rightX+6, y);
+
+   cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(wl->fixCurve->widget));
+   gdk_cairo_set_source_color(cr, Closure->greenSector);
+   cairo_set_line_width(cr, 1.0);
+   cairo_move_to(cr, wl->fixCurve->leftX-5.5, y+0.5);
+   cairo_line_to(cr, wl->fixCurve->rightX+5.5, y+0.5);
+   cairo_stroke(cr);
 }
 
 /*

--- a/src/rs02-window.c
+++ b/src/rs02-window.c
@@ -158,47 +158,8 @@ void RS02UpdateFixResults(RS02Widgets *wl, gint64 corrected, gint64 uncorrected)
 
 static gboolean curve_idle_func(gpointer data)
 {  RS02Widgets *wl = (RS02Widgets*)data;
-   gint x0 = GuiCurveX(wl->fixCurve, (double)wl->lastPercent);
-   gint x1 = GuiCurveX(wl->fixCurve, (double)wl->percent);
-   gint y = GuiCurveY(wl->fixCurve, wl->fixCurve->ivalue[wl->percent]);
-   gint i;
+   gtk_widget_queue_draw(wl->fixCurve->widget);
 
-   /*** Mark unused ecc values */
-
-   for(i=wl->lastPercent+1; i<wl->percent; i++)
-      wl->fixCurve->ivalue[i] = wl->fixCurve->ivalue[wl->percent];
-
-   /*** Resize the Y axes if error values exceeds current maximum */
-
-   if(wl->fixCurve->ivalue[wl->percent] > wl->fixCurve->maxY)
-   {  wl->fixCurve->maxY = wl->fixCurve->ivalue[wl->percent];
-      wl->fixCurve->maxY = wl->fixCurve->maxY - (wl->fixCurve->maxY % 5) + 5;
-
-      update_geometry(wl);
-      gdk_window_clear(gtk_widget_get_window(wl->fixCurve->widget));
-      redraw_curve(wl);
-      wl->lastPercent = wl->percent;
-
-      return FALSE;
-   }
-
-   /*** Draw the error value */
-
-   if(wl->fixCurve->ivalue[wl->percent] > 0)
-   {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->barColor);
-      gdk_draw_rectangle(wl->fixCurve->widget->window,
-			 Closure->drawGC, TRUE,
-			 x0, y, x0==x1 ? 1 : x1-x0, wl->fixCurve->bottomY-y);
-   }
-   wl->lastPercent = wl->percent;
-
-   /* Redraw the ecc capacity threshold line */
-
-   y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->greenSector);
-   gdk_draw_line(wl->fixCurve->widget->window,
-		 Closure->drawGC,
-		 wl->fixCurve->leftX-6, y, wl->fixCurve->rightX+6, y);
    return FALSE;
 }
 

--- a/src/rs03-verify.c
+++ b/src/rs03-verify.c
@@ -91,7 +91,7 @@ static gboolean spiral_idle_func(gpointer data)
    int i;
 
    for(i=sii->from; i<=sii->to; i++)
-     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, i-1);
+     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, 0, i-1);
 
    g_free(sii);
    return FALSE;

--- a/src/rs03-verify.c
+++ b/src/rs03-verify.c
@@ -91,7 +91,7 @@ static gboolean spiral_idle_func(gpointer data)
    int i;
 
    for(i=sii->from; i<=sii->to; i++)
-     GuiDrawSpiralSegment(sii->cmpSpiral, sii->segColor, 0, i-1);
+     GuiSetSpiralSegmentColor(sii->cmpSpiral, sii->segColor, 0, i-1);
 
    g_free(sii);
    return FALSE;

--- a/src/rs03-verify.c
+++ b/src/rs03-verify.c
@@ -124,19 +124,19 @@ static void add_verify_values(Method *method, int percent,
  * Redraw whole spiral
  */
 
-static void redraw_spiral(RS03Widgets *wl)
+static void redraw_spiral(cairo_t *cr, RS03Widgets *wl)
 {  int x = wl->cmpSpiral->mx - wl->cmpSpiral->diameter/2 + 10;
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Good sectors"), Closure->greenSector, x, 1);
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Sectors with CRC errors"), Closure->yellowSector, x, 2);
 
-   GuiDrawSpiralLabel(wl->cmpSpiral, wl->cmpLayout,
+   GuiDrawSpiralLabel(cr, wl->cmpSpiral, wl->cmpLayout,
 		      _("Missing sectors"), Closure->redSector, x, 3);
 
-   GuiDrawSpiral(wl->cmpSpiral);
+   GuiDrawSpiral(cr, wl->cmpSpiral);
 }
 
 /*
@@ -144,7 +144,8 @@ static void redraw_spiral(RS03Widgets *wl)
  */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  RS03Widgets *wl = (RS03Widgets*)data;
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   RS03Widgets *wl = (RS03Widgets*)data;
    GtkAllocation a = {0};
    gtk_widget_get_allocation(widget, &a);
    int w,h,size;
@@ -163,7 +164,7 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
    wl->cmpSpiral->my = (wl->cmpSpiral->diameter + a.height - size)/2;
 
    if(!event->count)      /* Exposure compression */
-     redraw_spiral(wl);   /* Redraw the spiral */
+     redraw_spiral(cr, wl);   /* Redraw the spiral */
 
    return TRUE;
 }

--- a/src/rs03-verify.c
+++ b/src/rs03-verify.c
@@ -69,7 +69,8 @@ void ResetRS03VerifyWindow(Method *self)
    wl->lastPercent = 0;
 
    GuiFillSpiral(wl->cmpSpiral, Closure->background);
-   GuiDrawSpiral(wl->cmpSpiral);
+   if (wl->cmpSpiral->widget)
+      gtk_widget_queue_draw(wl->cmpSpiral->widget);
 }
 
 /***

--- a/src/rs03-window.c
+++ b/src/rs03-window.c
@@ -31,7 +31,7 @@
  *** Forward declarations
  ***/
 
-static void redraw_curve(RS03Widgets*);
+static void redraw_curve(cairo_t *cr, RS03Widgets*);
 static void update_geometry(RS03Widgets*);
 
 /***
@@ -227,19 +227,18 @@ static void update_geometry(RS03Widgets *wl)
 			     TRUE, TRUE, wl->fixCurve->leftX, GTK_PACK_START);
 }
 
-static void redraw_curve(RS03Widgets *wl)
+static void redraw_curve(cairo_t *cr, RS03Widgets *wl)
 {  int y;
 
    /* Redraw the curve */
 
-   GuiRedrawAxes(wl->fixCurve);
-   GuiRedrawCurve(wl->fixCurve, wl->percent);
+   GuiRedrawAxes(cr, wl->fixCurve);
+   GuiRedrawCurve(cr, wl->fixCurve, wl->percent);
 
    /* Ecc capacity threshold line */
 
    y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
 
-   cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(wl->fixCurve->widget));
    gdk_cairo_set_source_color(cr, Closure->greenSector);
    cairo_set_line_width(cr, 1.0);
    cairo_move_to(cr, wl->fixCurve->leftX-5.5, y+0.5);
@@ -252,13 +251,14 @@ static void redraw_curve(RS03Widgets *wl)
  */
 
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
-{  RS03Widgets *wl = (RS03Widgets*)data; 
+{  cairo_t *cr = gdk_cairo_create(GDK_DRAWABLE(gtk_widget_get_window(widget)));
+   RS03Widgets *wl = (RS03Widgets*)data;
 
    if(event->count) /* Exposure compression */
      return TRUE;
 
    update_geometry(wl);
-   redraw_curve(wl);
+   redraw_curve(cr, wl);
 
    return TRUE;
 }

--- a/src/rs03-window.c
+++ b/src/rs03-window.c
@@ -144,7 +144,7 @@ void CreateRS03EncWindow(Method *method, GtkWidget *parent)
 static gboolean set_max_idle_func(gpointer data)
 {  RS03Widgets *wl = (RS03Widgets*)data;
 
-   redraw_curve(wl);
+   gtk_widget_queue_draw(wl->fixCurve->widget);
 
    return FALSE;
 }
@@ -269,9 +269,7 @@ void ResetRS03FixWindow(Method *method)
    RS03UpdateFixResults(wl, 0, 0);
 
    if(wl->fixCurve && wl->fixCurve->widget)
-   {  gdk_window_clear(gtk_widget_get_window(wl->fixCurve->widget));
-      redraw_curve(wl);
-   }
+      gtk_widget_queue_draw(wl->fixCurve->widget);
 
    wl->percent = 0;
    wl->lastPercent = 0;

--- a/src/rs03-window.c
+++ b/src/rs03-window.c
@@ -238,10 +238,13 @@ static void redraw_curve(RS03Widgets *wl)
    /* Ecc capacity threshold line */
 
    y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->greenSector);
-   gdk_draw_line(gtk_widget_get_window(wl->fixCurve->widget),
-		 Closure->drawGC,
-		 wl->fixCurve->leftX-6, y, wl->fixCurve->rightX+6, y);
+
+   cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(wl->fixCurve->widget));
+   gdk_cairo_set_source_color(cr, Closure->greenSector);
+   cairo_set_line_width(cr, 1.0);
+   cairo_move_to(cr, wl->fixCurve->leftX-5.5, y+0.5);
+   cairo_line_to(cr, wl->fixCurve->rightX+5.5, y+0.5);
+   cairo_stroke(cr);
 }
 
 /*

--- a/src/rs03-window.c
+++ b/src/rs03-window.c
@@ -188,47 +188,8 @@ void RS03UpdateFixResults(RS03Widgets *wl, gint64 corrected, gint64 uncorrected)
 
 static gboolean curve_idle_func(gpointer data)
 {  RS03Widgets *wl = (RS03Widgets*)data;
-   gint x0 = GuiCurveX(wl->fixCurve, (double)wl->lastPercent);
-   gint x1 = GuiCurveX(wl->fixCurve, (double)wl->percent);
-   gint y = GuiCurveY(wl->fixCurve, wl->fixCurve->ivalue[wl->percent]);
-   gint i;
+   gtk_widget_queue_draw(wl->fixCurve->widget);
 
-   /*** Mark unused ecc values */
-
-   for(i=wl->lastPercent+1; i<wl->percent; i++)
-      wl->fixCurve->ivalue[i] = wl->fixCurve->ivalue[wl->percent];
-
-   /*** Resize the Y axes if error values exceeds current maximum */
-
-   if(wl->fixCurve->ivalue[wl->percent] > wl->fixCurve->maxY)
-   {  wl->fixCurve->maxY = wl->fixCurve->ivalue[wl->percent];
-      wl->fixCurve->maxY = wl->fixCurve->maxY - (wl->fixCurve->maxY % 5) + 5;
-
-      update_geometry(wl);
-      gdk_window_clear(gtk_widget_get_window(wl->fixCurve->widget));
-      redraw_curve(wl);
-      wl->lastPercent = wl->percent;
-
-      return FALSE;
-   }
-
-   /*** Draw the error value */
-
-   if(wl->fixCurve->ivalue[wl->percent] > 0)
-   {  gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->barColor);
-      gdk_draw_rectangle(wl->fixCurve->widget->window,
-			 Closure->drawGC, TRUE,
-			 x0, y, x0==x1 ? 1 : x1-x0, wl->fixCurve->bottomY-y);
-   }
-   wl->lastPercent = wl->percent;
-
-   /* Redraw the ecc capacity threshold line */
-
-   y = GuiCurveY(wl->fixCurve, wl->eccBytes);  
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->greenSector);
-   gdk_draw_line(gtk_widget_get_window(wl->fixCurve->widget),
-		 Closure->drawGC,
-		 wl->fixCurve->leftX-6, y, wl->fixCurve->rightX+6, y);
    return FALSE;
 }
 

--- a/src/spiral.c
+++ b/src/spiral.c
@@ -73,8 +73,8 @@ void GuiSetSpiralWidget(Spiral *spiral, GtkWidget *widget)
 {  GtkAllocation a = {0};
    gtk_widget_get_allocation(widget, &a);
 
-   if(!spiral->drawable)
-   {  spiral->drawable     = gtk_widget_get_window(widget);
+   if(!spiral->widget)
+   {  spiral->widget       = widget;
       spiral->mx           = a.width/2;
       spiral->my           = a.height/2;
    }
@@ -105,13 +105,15 @@ void GuiFillSpiral(Spiral *spiral, GdkColor *color)
  */
 
 void GuiDrawSpiral(Spiral *spiral)
-{  double a;
+{  GdkDrawable *d;
+   double a;
    int xi0,yi0,xo0,yo0;
    double scale_i,scale_o;
    int i;
    GdkPoint points[4];
 
-   if(!spiral->drawable) return;
+   if(!spiral->widget) return;
+   d = gtk_widget_get_window(spiral->widget);
 
    scale_i = spiral->startRadius;
    scale_o = spiral->startRadius + spiral->segmentSize;
@@ -138,9 +140,9 @@ void GuiDrawSpiral(Spiral *spiral)
       points[3].x = xi1; points[3].y = yi1;
 
       gdk_gc_set_rgb_fg_color(Closure->drawGC, spiral->segmentColor[i]);
-      gdk_draw_polygon(spiral->drawable, Closure->drawGC, TRUE, points, 4);
+      gdk_draw_polygon(d, Closure->drawGC, TRUE, points, 4);
       gdk_gc_set_rgb_fg_color(Closure->drawGC, spiral->outline);
-      gdk_draw_polygon(spiral->drawable, Closure->drawGC, FALSE, points, 4);
+      gdk_draw_polygon(d, Closure->drawGC, FALSE, points, 4);
 
       xi0 = xi1; yi0 = yi1;
       xo0 = xo1; yo0 = yo1;
@@ -152,7 +154,8 @@ void GuiDrawSpiral(Spiral *spiral)
  */
 
 void GuiDrawSpiralSegment(Spiral *spiral, GdkColor *color, int segment)
-{  double a;
+{  GdkDrawable *d = gtk_widget_get_window(spiral->widget);
+   double a;
    double scale_i,scale_o,ring_expand;
    GdkPoint points[4];
 
@@ -183,9 +186,9 @@ void GuiDrawSpiralSegment(Spiral *spiral, GdkColor *color, int segment)
 
    spiral->segmentColor[segment] = color;
    gdk_gc_set_rgb_fg_color(Closure->drawGC, color);
-   gdk_draw_polygon(spiral->drawable, Closure->drawGC, TRUE, points, 4);
+   gdk_draw_polygon(d, Closure->drawGC, TRUE, points, 4);
    gdk_gc_set_rgb_fg_color(Closure->drawGC, spiral->outline);
-   gdk_draw_polygon(spiral->drawable, Closure->drawGC, FALSE, points, 4);
+   gdk_draw_polygon(d, Closure->drawGC, FALSE, points, 4);
 }
 
 /*
@@ -194,7 +197,7 @@ void GuiDrawSpiralSegment(Spiral *spiral, GdkColor *color, int segment)
 
 void GuiDrawSpiralLabel(Spiral *spiral, PangoLayout *layout,
 			char *text, GdkColor *color, int x, int line)
-{  GdkDrawable *d = spiral->drawable;
+{  GdkDrawable *d = gtk_widget_get_window(spiral->widget);
    int w,h,y;
 
    GuiSetText(layout, text, &w, &h);

--- a/src/spiral.c
+++ b/src/spiral.c
@@ -111,15 +111,15 @@ void GuiFillSpiral(Spiral *spiral, GdkColor *color)
  */
 
 void GuiDrawSpiral(Spiral *spiral)
-{  GdkDrawable *d;
+{  cairo_t *cr;
    double a;
-   int xi0,yi0,xo0,yo0;
+   double xi0,yi0,xo0,yo0;
    double scale_i,scale_o;
    int i;
-   GdkPoint points[4];
 
    if(!spiral->widget) return;
-   d = gtk_widget_get_window(spiral->widget);
+   cr = gdk_cairo_create(gtk_widget_get_window(spiral->widget));
+   cairo_set_line_width(cr, 1.0);
 
    scale_i = spiral->startRadius;
    scale_o = spiral->startRadius + spiral->segmentSize;
@@ -128,7 +128,7 @@ void GuiDrawSpiral(Spiral *spiral)
    xo0 = xi0 + spiral->segmentSize;
 
    for(a=0.0, i=0; i<spiral->segmentClipping; i++)
-   {  int xi1,yi1,xo1,yo1;
+   {  double xi1,yi1,xo1,yo1;
       double ring_expand = ((double)spiral->segmentSize * a) / (2.0*M_PI);
 
       a += atan((double)spiral->segmentSize / scale_o);
@@ -140,20 +140,18 @@ void GuiDrawSpiral(Spiral *spiral)
       xo1 = spiral->mx + scale_o*cos(a);
       yo1 = spiral->my + scale_o*sin(a);
 
-      points[0].x = xi0; points[0].y = yi0;
-      points[1].x = xo0; points[1].y = yo0;
-      points[2].x = xo1; points[2].y = yo1;
-      points[3].x = xi1; points[3].y = yi1;
 
       GdkColor *outline = spiral->segmentOutline[i] ? spiral->segmentOutline[i] : Closure->grid;
 
-      if (i == spiral->cursorPos)
-         gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->blueSector);
-      else
-         gdk_gc_set_rgb_fg_color(Closure->drawGC, spiral->segmentColor[i]);
-      gdk_draw_polygon(d, Closure->drawGC, TRUE, points, 4);
-      gdk_gc_set_rgb_fg_color(Closure->drawGC, outline);
-      gdk_draw_polygon(d, Closure->drawGC, FALSE, points, 4);
+      cairo_move_to(cr, xi0, yi0);
+      cairo_line_to(cr, xo0, yo0);
+      cairo_line_to(cr, xo1, yo1);
+      cairo_line_to(cr, xi1, yi1);
+      cairo_close_path(cr);
+      gdk_cairo_set_source_color(cr, spiral->segmentColor[i]);
+      cairo_fill_preserve(cr);
+      gdk_cairo_set_source_color(cr, outline);
+      cairo_stroke(cr);
 
       xi0 = xi1; yi0 = yi1;
       xo0 = xo1; yo0 = yo1;
@@ -182,18 +180,22 @@ void GuiSetSpiralSegmentColor(Spiral *spiral, GdkColor *color, GdkColor *outline
 
 void GuiDrawSpiralLabel(Spiral *spiral, PangoLayout *layout,
 			char *text, GdkColor *color, int x, int line)
-{  GdkDrawable *d = gtk_widget_get_window(spiral->widget);
+{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(spiral->widget));
    int w,h,y;
 
    GuiSetText(layout, text, &w, &h);
    if(line > 0) y = spiral->my + spiral->diameter / 2 + 20 + (line-1) * (10 + h); 
    else         y = spiral->my - spiral->diameter / 2 - 20 - h + (line+1) * (10 + h); 
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, color);
-   gdk_draw_rectangle(d, Closure->drawGC, TRUE, x, y+(h-6)/2, 6, 6);
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->grid);
-   gdk_draw_rectangle(d, Closure->drawGC, FALSE, x, y+(h-6)/2, 6, 6);
-   gdk_gc_set_rgb_fg_color(Closure->drawGC, Closure->foreground);
-   gdk_draw_layout(d, Closure->drawGC, x+10, y, layout);
+   cairo_rectangle(cr, x + 0.5, y+(h-6)/2 + 0.5, 6, 6);
+   gdk_cairo_set_source_color(cr, color);
+   cairo_fill_preserve(cr);
+   gdk_cairo_set_source_color(cr, Closure->grid);
+   cairo_set_line_width(cr, 1.0);
+   cairo_stroke(cr);
+
+   cairo_move_to(cr, x+10, y);
+   gdk_cairo_set_source_color(cr, Closure->foreground);
+   pango_cairo_show_layout(cr, layout);
 }
 
 /* 

--- a/src/spiral.c
+++ b/src/spiral.c
@@ -164,7 +164,7 @@ void GuiDrawSpiral(Spiral *spiral)
  * Draw just one segment of the spiral
  */
 
-void GuiDrawSpiralSegment(Spiral *spiral, GdkColor *color, GdkColor *outline, int segment)
+void GuiSetSpiralSegmentColor(Spiral *spiral, GdkColor *color, GdkColor *outline, int segment)
 {
    if(segment<0 || segment>=spiral->segmentClipping)
      return;

--- a/src/spiral.c
+++ b/src/spiral.c
@@ -110,15 +110,14 @@ void GuiFillSpiral(Spiral *spiral, GdkColor *color)
  * Draw the whole spiral
  */
 
-void GuiDrawSpiral(Spiral *spiral)
-{  cairo_t *cr;
-   double a;
+void GuiDrawSpiral(cairo_t *cr, Spiral *spiral)
+{  double a;
    double xi0,yi0,xo0,yo0;
    double scale_i,scale_o;
    int i;
 
    if(!spiral->widget) return;
-   cr = gdk_cairo_create(gtk_widget_get_window(spiral->widget));
+
    cairo_set_line_width(cr, 1.0);
 
    scale_i = spiral->startRadius;
@@ -178,10 +177,9 @@ void GuiSetSpiralSegmentColor(Spiral *spiral, GdkColor *color, GdkColor *outline
  * Draw a label above or below the spiral
  */
 
-void GuiDrawSpiralLabel(Spiral *spiral, PangoLayout *layout,
+void GuiDrawSpiralLabel(cairo_t *cr, Spiral *spiral, PangoLayout *layout,
 			char *text, GdkColor *color, int x, int line)
-{  cairo_t *cr = gdk_cairo_create(gtk_widget_get_window(spiral->widget));
-   int w,h,y;
+{  int w,h,y;
 
    GuiSetText(layout, text, &w, &h);
    if(line > 0) y = spiral->my + spiral->diameter / 2 + 20 + (line-1) * (10 + h); 

--- a/src/welcome-window.c
+++ b/src/welcome-window.c
@@ -43,11 +43,9 @@ static void toggle_cb(GtkWidget *widget, gpointer data)
 static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer data)
 {  GtkWidget *box = (GtkWidget*)data;
 
-   if(!Closure->drawGC)
+   if(!Closure->colors_initialized)
    {  GdkColor *bg = &widget->style->bg[0];
       GdkColormap *cmap = gdk_colormap_get_system();
-
-      Closure->drawGC = gdk_gc_new(gtk_widget_get_window(widget));
 
       memcpy(Closure->background, bg, sizeof(GdkColor));
 
@@ -71,6 +69,8 @@ static gboolean expose_cb(GtkWidget *widget, GdkEventExpose *event, gpointer dat
       gdk_colormap_alloc_color(cmap, Closure->blueSector, FALSE, TRUE);
       gdk_colormap_alloc_color(cmap, Closure->whiteSector, FALSE, TRUE);
       gdk_colormap_alloc_color(cmap, Closure->darkSector, FALSE, TRUE);
+
+      Closure->colors_initialized = TRUE;
 
       /* Dirty trick for indenting the list:
 	 draw an invisible dash before each indented line */


### PR DESCRIPTION
A second part from https://github.com/speed47/dvdisaster/pull/109.

I was a little too late to find one mistake in https://github.com/speed47/dvdisaster/pull/114: The wrong filename for the current ecc file was passed to the file picker.

The last two commits are not related to the porting to gtk3. One fixes a grid line that is drawn on top of an axis, which makes 1 pixel grey that should be black. The other is to draw more grid lines in the speed curve for Blu-ray and HD-DVD discs. Blu-ray only got two horizontal lines at 4x and 8x (now at 2x, 4x, 6x and 8x), and HD-DVD did not get any (now at 1x, 2x and 3x).