### PR TITLE
AppImage for gtk3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,15 @@ name: autobuild
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dev'
     tags:
-      - "v*"
+      - 'v*'
 
 jobs:
   mac:
-    runs-on: macos-11
+    runs-on: macos-13
     strategy:
       matrix:
         ui: [cli, gui]
@@ -16,8 +19,6 @@ jobs:
             clionly: --with-gui=no
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: install prerequisites
         env:
           HOMEBREW_NO_INSTALL_CLEANUP: 1
@@ -50,11 +51,44 @@ jobs:
       - name: build dist
         run: ./.github/workflows/make-mac-app.sh ${{ github.ref }}
         id: dist
-      - name: Release
+      - name: Tag for Continuous Build
+        if: github.ref_name == 'master'
+        run: |
+          git tag -f latest
+          git push -f origin latest
+      - name: Upload to Continuous Build
+        if: github.ref_name == 'master'
         uses: softprops/action-gh-release@v2
         with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          name: "Continuous Build"
+          tag_name: latest
           files: ${{ steps.dist.outputs.archive }}
+      - name: Tag for Dev Build
+        if: github.ref_name == 'dev'
+        run: |
+          git tag -f devel
+          git push -f origin devel
+      - name: Upload to Dev Build
+        if: github.ref_name == 'dev'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
           draft: true
+          name: "Dev Build"
+          tag_name: devel
+          files: ${{ steps.dist.outputs.archive }}
+      - name: Upload to Draft Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: ${{ steps.dist.outputs.archive }}
 
   win:
     runs-on: windows-latest
@@ -87,8 +121,6 @@ jobs:
         run: git config --global core.autocrlf input
         shell: bash
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: configure
         run: ./configure ${{ matrix.clionly }}
       - name: make
@@ -114,18 +146,49 @@ jobs:
         run: |
           cd dist
           dvdisaster.exe --version
-      - name: Release
+      - name: Tag for Continuous Build
+        if: github.ref_name == 'master'
+        run: |
+          git tag -f latest
+          git push -f origin latest
+      - name: Upload to Continuous Build
+        if: github.ref_name == 'master'
         uses: softprops/action-gh-release@v2
         with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          name: "Continuous Build"
+          tag_name: latest
           files: ${{ steps.dist.outputs.archive }}
+      - name: Tag for Dev Build
+        if: github.ref_name == 'dev'
+        run: |
+          git tag -f devel
+          git push -f origin devel
+      - name: Upload to Dev Build
+        if: github.ref_name == 'dev'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
           draft: true
+          name: "Dev Build"
+          tag_name: devel
+          files: ${{ steps.dist.outputs.archive }}
+      - name: Upload to Draft Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: ${{ steps.dist.outputs.archive }}
 
   linux64-cli:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: install prerequisites
         run: sudo apt update && sudo apt install -y libglib2.0-dev ghostscript man
       - name: configure
@@ -140,53 +203,93 @@ jobs:
       - name: build dist
         run: ./.github/workflows/make-dist.sh ${{ github.ref }}
         id: dist
-      - name: Release
+      - name: Tag for Continuous Build
+        if: github.ref_name == 'master'
+        run: |
+          git tag -f latest
+          git push -f origin latest
+      - name: Upload to Continuous Build
+        if: github.ref_name == 'master'
         uses: softprops/action-gh-release@v2
         with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          name: "Continuous Build"
+          tag_name: latest
           files: ${{ steps.dist.outputs.archive }}
+      - name: Tag for Dev Build
+        if: github.ref_name == 'dev'
+        run: |
+          git tag -f devel
+          git push -f origin devel
+      - name: Upload to Dev Build
+        if: github.ref_name == 'dev'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
           draft: true
+          name: "Dev Build"
+          tag_name: devel
+          files: ${{ steps.dist.outputs.archive }}
+      - name: Upload to Draft Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: ${{ steps.dist.outputs.archive }}
 
   linux64-appimage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: install prerequisites on host
         run: sudo apt-get update && sudo apt-get install -y fuse
       - name: docker
         run: |
           mkdir -p /tmp/dist
-          docker run --device /dev/fuse --privileged --name uu -d -v $PWD:/code -v /tmp/dist:/dist ubuntu:14.04 sleep 1800
+          docker run --device /dev/fuse --privileged --name uu -d -v $PWD:/dvdisaster -v /tmp/dist:/dist ubuntu:18.04 sleep 1800
       - name: install prerequisites in docker
-        run: docker exec uu sh -c 'sudo apt update && sudo apt install -y libglib2.0-dev ghostscript man libgtk3-dev libgail-common pkg-config gnome-themes-standard fuse'
+        run: docker exec uu sh -c 'apt update && apt install -y ghostscript man fuse file make gcc pkg-config libglib2.0-dev libgtk-3-dev glib-networking libgdk-pixbuf2.0-dev'
       - name: configure in docker
-        run: docker exec uu sh -c 'cd /code && ./configure --prefix=/usr'
+        run: docker exec uu sh -c 'cd /dvdisaster && ./configure --prefix=/usr'
       - name: make in docker
-        run: docker exec uu sh -c 'make -C /code -j$(nproc) && make -C /code'
+        run: docker exec uu sh -c 'make -C /dvdisaster -j$(nproc) && make -C /dvdisaster'
       - name: make install in docker
-        run: docker exec uu sh -c 'cd /code && touch documentation/user-manual/manual.pdf && make install DESTDIR=/dist'
-      - name: copy things to dist in docker
+        run: docker exec uu sh -c 'cd /dvdisaster && touch documentation/user-manual/manual.pdf && make install DESTDIR=/dist'
+      - name: copy gtk3 and gio stuff to dist in docker
         run: |
-          docker exec uu sh -c 'install -d /dist/usr/lib/gtk-2.0 && cp -va $(pkg-config --variable=libdir gtk+-2.0)/gtk-2.0/$(pkg-config --variable=gtk_binary_version gtk+-2.0)/* /dist/usr/lib/gtk-2.0'
-          docker exec uu sh -c 'cp -va $(pkg-config --variable=libdir gtk+-2.0)/gtk-2.0/modules /dist/usr/lib/gtk-2.0/'
-      - name: build appimage in docker
+          set -euo pipefail
+          docker exec uu sh -c 'install -d /dist/usr/lib/gtk-3.0 && cp -va $(pkg-config --variable=libdir gtk+-3.0)/gtk-3.0/* /dist/usr/lib/gtk-3.0'
+          docker exec uu sh -c 'install -d /dist/usr/lib/gio/modules && cp -va $(dirname $(dpkg -L glib-networking | grep -F /libgiolibproxy.so | head -n1))/* /dist/usr/lib/gio/modules/'
+          docker exec uu sh -c 'gio-querymodules /dist/usr/lib/gio/modules'
+          docker exec uu sh -c 'install -d /dist/usr/lib/gdk-pixbuf2 && timeout 10 cp -va $(dirname $(find /usr/lib -name "libpixbufloader-*.so" | head -n1))/../* /dist/usr/lib/gdk-pixbuf2/'
+          docker exec uu sh -c 'gdk-pixbuf-query-loaders > /dist/usr/lib/gdk-pixbuf2/loaders.cache'
+          IM_BASEPATH=$(dirname $(cd /tmp/dist; find . -name immodules.cache))/immodules
+          sudo sed -i -re 's=^"/.+/immodules/(.+)="'$IM_BASEPATH'/\1=' $(find /tmp/dist/ -name immodules.cache)
+          PIX_BASEPATH=$(dirname $(cd /tmp/dist; find . -name loaders.cache))/
+          sudo sed -i -re 's=^"/.+/loaders/(.+)="'$PIX_BASEPATH'/loaders/\1=' $(find /tmp/dist/ -name loaders.cache)
+      - name: build appimage in docker with linuxdeploy
         run: |
           wget -q https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           chmod 755 linuxdeploy-x86_64.AppImage
-          docker exec -e LINUXDEPLOY_OUTPUT_VERSION=$(echo "${{ github.ref }}" | grep -Eo '[^/]+$') -e ARCH=x86_64 uu sh -c 'cd /code && ./linuxdeploy-x86_64.AppImage -d contrib/dvdisaster.desktop -i contrib/dvdisaster64.png -i contrib/dvdisaster48.png -i contrib/dvdisaster32.png -i contrib/dvdisaster16.png --icon-filename dvdisaster --custom-apprun=contrib/AppRun.sh --appdir /dist/ --output appimage'
+          docker exec -e LINUXDEPLOY_OUTPUT_VERSION=$(echo "${{ github.ref }}" | grep -Eo '[^/]+$') -e ARCH=x86_64 uu sh -c 'cd /dvdisaster && ./linuxdeploy-x86_64.AppImage -d contrib/dvdisaster.desktop -i contrib/dvdisaster64.png -i contrib/dvdisaster48.png -i contrib/dvdisaster32.png -i contrib/dvdisaster16.png --icon-filename dvdisaster --custom-apprun=contrib/AppRun.sh --appdir /dist/ --output appimage'
       - name: fix perms
-        run: docker exec uu sh -c "chown -R $UID /dist /code/*.AppImage"
-      - name: apply glib workaround
+        run: docker exec uu sh -c "chown -R $UID /dist /dvdisaster/*.AppImage"
+      - name: patch libgio and apply glib workaround by repackaging with appimagetool
         env:
           ARCH: x86_64
         run: |
-          wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          wget -q https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod 755 appimagetool-x86_64.AppImage
           exe=$(ls -1 dvdisaster*.AppImage)
           chmod 755 $exe
           ./$exe --appimage-extract
           rm -vf $exe
+          sed -i -re "s=gio/modules=:::::::::::=g" squashfs-root/usr/lib/libgio*.so*
           env LINUXDEPLOY_OUTPUT_VERSION=$(echo "${{ github.ref }}" | grep -Eo '[^/]+$') ./appimagetool-x86_64.AppImage -v squashfs-root
           mv -v dvdisaster*AppImage $exe
           chmod 755 $exe
@@ -197,8 +300,41 @@ jobs:
           archive=$(ls -1 dvdisaster*.AppImage)
           echo "archive=$archive" >> "$GITHUB_OUTPUT"
           echo "appimage is <$archive>"
-      - name: Release
+      - name: Tag for Continuous Build
+        if: github.ref_name == 'master'
+        run: |
+          git tag -f latest
+          git push -f origin latest
+      - name: Upload to Continuous Build
+        if: github.ref_name == 'master'
         uses: softprops/action-gh-release@v2
         with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          name: "Continuous Build"
+          tag_name: latest
           files: ${{ steps.dist.outputs.archive }}
+      - name: Tag for Dev Build
+        if: github.ref_name == 'dev'
+        run: |
+          git tag -f devel
+          git push -f origin devel
+      - name: Upload to Dev Build
+        if: github.ref_name == 'dev'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
           draft: true
+          name: "Dev Build"
+          tag_name: devel
+          files: ${{ steps.dist.outputs.archive }}
+      - name: Upload to Draft Release
+        if: github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          files: ${{ steps.dist.outputs.archive }}

--- a/contrib/AppRun.sh
+++ b/contrib/AppRun.sh
@@ -1,6 +1,79 @@
 #!/bin/sh
 DIR="$(readlink -f "$(dirname "$0")")"
-export GTK_PATH="$DIR/usr/lib/gtk-2.0"
-export GTK_IM_MODULE_FILE=/dev/null
-export DVDISASTER_DOCDIR="$DIR/usr/share/doc/dvdisaster"
+
+# When adding environment variables in this script, don't forget to sync with the src/show-manual.c
+# list, as they need to be cleaned up before calling xdg-open to ensure xdg-open works with all the
+# libs from the host and none from the AppImage (which most of the time just doesn't work).
+# Also save the original value into an _ORIGINAL variable, which will be restored by dvdisaster
+# into the xdg-open's environment before calling execve()
+
+# Point to our own gtk libs
+[ "_$GTK_PATH" != _ ] && export GTK_PATH_ORIGINAL="$GTK_PATH"
+export GTK_PATH="$DIR/usr/lib/gtk-3.0"
+
+# Load our own modules instead of the host ones,
+# an absolute path pointing to the host is unfortunately hardcoded in ./usr/lib/libgio-2.0.so.0,
+# but we edited the lib to neutralize said path (replaced gio/modules by :'s):
+#
+# $ strings ./usr/lib/libgio-2.0.so.0 | grep :::
+# /usr/lib/:::::::::::
+# /usr/lib/x86_64-linux-gnu/:::::::::::
+#
+# So the path below should be the only one used in the end:
+[ "_$GIO_EXTRA_MODULES" != _ ] && export GIO_EXTRA_MODULES_ORIGINAL="$GIO_EXTRA_MODULES"
+export GIO_EXTRA_MODULES="$DIR/usr/lib/gio/modules"
+
+# To avoid getting:
+# '''
+# (dvdisaster:16170): Gtk-WARNING **: 14:31:41.224: Loading IM context type 'ibus' failed
+# (dvdisaster:16170): Gtk-WARNING **: 14:31:41.224: /lib/x86_64-linux-gnu/libibus-1.0.so.5: undefined symbol: g_get_language_names_with_category
+# '''
+# We use xim instead, which is included in our build, along with the proper immodules cache file referencing our modules
+[ "_$GTK_IM_MODULE_FILE" != _ ] && export GTK_IM_MODULE_FILE_ORIGINAL="$GTK_IM_MODULE_FILE"
+export GTK_IM_MODULE_FILE="$(find "$DIR/" -name immodules.cache)"
+[ "_$GTK_IM_MODULE" != _ ] && export GTK_IM_MODULE_ORIGINAL="$GTK_IM_MODULE"
+export GTK_IM_MODULE=xim
+
+# if host has GTK_MODULES set, empty it to prevent it from loading modules from the host
+[ "_$GTK_MODULES" != _ ] && export GTK_MODULES_ORIGINAL="$GTK_MODULES"
+export GTK_MODULES=''
+
+# To avoid getting:
+# '''
+# (dvdisaster:16133): GLib-GIO-ERROR **: 14:25:53.270: Settings schema 'org.gnome.settings-daemon.plugins.xsettings' does not contain a key named 'antialiasing'
+# Trace/breakpoint trap (core dumped)
+# '''
+# Under Ubuntu 22.04 and possibly later versions using Wayland
+# https://github.com/Ultimaker/Cura/issues/12776
+[ "_$GDK_BACKEND" != _ ] && export GDK_BACKEND_ORIGINAL="$GDK_BACKEND_ORIGINAL"
+export GDK_BACKEND=x11
+
+# To avoid getting:
+# '''
+# (evince:172616): dbind-WARNING **: 18:02:34.901: Couldn't connect to accessibility bus: Failed to connect to socket /run/user/1000/at-spi/bus: Permission denied
+# '''
+[ "_$NO_AT_BRIDGE" != _ ] && export NO_AT_BRIDGE_ORIGINAL="$NO_AT_BRIDGE"
+export NO_AT_BRIDGE=1
+
+# To avoid getting:
+# '''
+# (dvdisaster:20080): Gtk-WARNING **: 15:43:20.719: Could not load a pixbuf from icon theme.
+# This may indicate that pixbuf loaders or the mime database could not be found.
+# '''
+# Point to our own patched cache file for gdk-pixbuf2
+[ "_$GDK_PIXBUF_MODULE_FILE" != _ ] && export GDK_PIXBUF_MODULE_FILE_ORIGINAL="$GDK_PIXBUF_MODULE_FILE"
+export GDK_PIXBUF_MODULE_FILE="$DIR/usr/lib/gdk-pixbuf2/loaders.cache"
+# As the pixbuf loaders depends themselves on other libs, also adjust LD_LIBRARY_PATH so they load properly
+[ "_$LD_LIBRARY_PATH" != _ ] && export LD_LIBRARY_PATH_ORIGINAL="$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$DIR/usr/lib:$LD_LIBRARY_PATH"
+
+# Change to the proper directory because some .cache files have relative paths starting with "."
+# we save the current PWD so that dvdisaster can use it as a default to store image and ecc files
+export ORIGINAL_PWD="$PWD"
+cd "$DIR" || exit 1
+
+# Now run the program, with 3 vars it uses at runtime
+export DVDISASTER_APPIMAGE=1
+export DOCDIR="$DIR/usr/share/doc/dvdisaster"
+export BINDIR="$DIR/usr/bin"
 exec "$DIR/usr/bin/dvdisaster" "$@"

--- a/src/closure.c
+++ b/src/closure.c
@@ -28,13 +28,6 @@
  #include "inlined-icons.h"
 #endif
 
-#if 0 
- #define Verbose g_printf
-#else
- #define Verbose(format, ...)
-#endif
-
-
 #ifdef SYS_MINGW
 #include <windows.h>
 

--- a/src/closure.c
+++ b/src/closure.c
@@ -386,6 +386,15 @@ static void update_dotfile()
 
 static void get_base_dirs()
 {  
+
+   /* If specified in environment (for example in AppImage), use it */
+   if (g_getenv("DVDISASTER_APPIMAGE") && atoi(g_getenv("DVDISASTER_APPIMAGE")) && g_getenv("DOCDIR") && g_getenv("BINDIR"))
+   {  Closure->binDir = g_strdup(g_getenv("BINDIR"));
+      Closure->docDir = g_strdup(g_getenv("DOCDIR"));
+      Verbose("Using paths from environment\n");
+      goto find_dotfile;
+   }
+
    /*** Unless completely disabled through a configure option, the
 	source directory is supposed to hold the most recent files,
 	so try this first. */
@@ -442,9 +451,7 @@ static void get_base_dirs()
    /*** The location of the dotfile depends on the operating system. 
 	Under Unix the users home directory is used. */
 
-#if defined(WITH_EMBEDDED_SRC_PATH_YES) && !defined(SYS_MINGW)
 find_dotfile:
-#endif /* WITH_EMBEDDED_SRC_PATH_YES */
    
 #ifndef SYS_MINGW
    Closure->homeDir = g_strdup(g_getenv("HOME"));
@@ -608,10 +615,16 @@ void InitClosure()
 
 void LocalizedFileDefaults()
 {  
-   /* Storing the files in the cwd appears to be a sane default. */
-
-   Closure->imageName   = g_strdup(_("medium.iso"));
-   Closure->eccName     = g_strdup(_("medium.ecc"));
+   if (g_getenv("DVDISASTER_APPIMAGE") && atoi(g_getenv("DVDISASTER_APPIMAGE")) && g_getenv("ORIGINAL_PWD"))
+   {  /* Under AppImage mode, use the ORIGINAL_PWD as the cwd is non-writable. */
+      Closure->imageName   = g_strdup_printf("%s/%s", g_getenv("ORIGINAL_PWD"), _("medium.iso"));
+      Closure->eccName     = g_strdup_printf("%s/%s", g_getenv("ORIGINAL_PWD"), _("medium.ecc"));
+   }
+   else
+   {  /* Storing the files in the cwd appears to be a sane default. */
+      Closure->imageName   = g_strdup(_("medium.iso"));
+      Closure->eccName     = g_strdup(_("medium.ecc"));
+   }
    Closure->dDumpPrefix = g_strdup(_("sector-"));
 }
 

--- a/src/closure.c
+++ b/src/closure.c
@@ -493,7 +493,7 @@ void InitClosure()
    /* Extract the version string */
 
 #if defined(HAVE_UNSTABLE_RELEASE) && defined(PATCHLEVEL)
-   Closure->cookedVersion = g_strdup_printf("%s (unstable-unofficial patchlevel %d)", VERSION, PATCHLEVEL);
+   Closure->cookedVersion = g_strdup_printf("%s (unofficial patchlevel %d)", VERSION, PATCHLEVEL);
    Closure->releaseFlags = MFLAG_DEVEL;
 #elif defined(HAVE_UNSTABLE_RELEASE)
    Closure->cookedVersion = g_strdup_printf("%s (unstable)", VERSION);

--- a/src/dvdisaster.c
+++ b/src/dvdisaster.c
@@ -975,7 +975,7 @@ int main(int argc, char *argv[])
       PrintCLI(_("  -m, --method x             - list/select error correction methods (default: RS01)\n"));
       PrintCLI(_("  -n, --redundancy n%%        - error correction data redundancy\n"
 		 "                               allowed values depend on codec (see manual)\n"));
-      PrintCLI(_("  -v, --verbose              - more diagnostic messages\n"));
+      PrintCLI(_("  -v, --verbose              - more logs, set env VERBOSE=1 for pre-options parsing logs\n"));
       PrintCLI(_("  -x, --threads n            - use n threads for en-/decoding (if supported by codec)\n"));
       PrintCLI(_("  --adaptive-read            - use optimized strategy for reading damaged media\n"));
       PrintCLI(_("  --auto-suffix              - automatically add .iso and .ecc file suffixes\n"));

--- a/src/dvdisaster.c
+++ b/src/dvdisaster.c
@@ -1074,6 +1074,9 @@ int main(int argc, char *argv[])
 	 }
       }
 
+      /* Going to use the GUI, tell the user most command-line options are ignored as we're restoring the GUI prefs */
+      PrintCLI(_("Using GUI mode: most command-line options are ignored. Look at the preferences in the GUI instead.\n"));
+
       Closure->guiMode = TRUE;
       GuiReadDotfile();
       GuiCreateMainWindow(&argc, &argv);

--- a/src/misc.c
+++ b/src/misc.c
@@ -411,7 +411,7 @@ void Verbose(char *format, ...)
       va_end(argp);
    }
 
-   if(!Closure->verbose)
+   if(!Closure->verbose && !g_getenv("VERBOSE"))
     return;
 
    va_start(argp, format);

--- a/src/show-manual.c
+++ b/src/show-manual.c
@@ -141,6 +141,35 @@ void GuiShowURL(char *target)
       /* close reading end of error pipe */
       close(err_pipe[0]);
 
+      /* cleanup env if we're called from AppImage */
+      if (g_getenv("DVDISASTER_APPIMAGE") && atoi(g_getenv("DVDISASTER_APPIMAGE")))
+      {
+         const char *namelist[] = {
+            "GDK_BACKEND",
+            "GDK_PIXBUF_MODULE_FILE",
+            "GIO_EXTRA_MODULES",
+            "GTK_IM_MODULE",
+            "GTK_IM_MODULE_FILE",
+            "GTK_MODULES",
+            "GTK_PATH",
+            "LD_LIBRARY_PATH",
+            "NO_AT_BRIDGE",
+            NULL,
+         };
+         for (int i = 0; namelist[i]; i++) {
+            gchar *original_name = g_strdup_printf("%s_ORIGINAL", namelist[i]);
+            if (g_getenv(original_name)) {
+              g_setenv(namelist[i], g_getenv(original_name), 1);
+              g_unsetenv(original_name);
+            }
+            else {
+              g_unsetenv(namelist[i]);
+            }
+            g_free(original_name);
+         }
+         g_unsetenv("DVDISASTER_APPIMAGE");
+      }
+
       /* prepare args and try to exec xdg-open */
       
       argv[argc++] = "xdg-open";

--- a/src/show-manual.c
+++ b/src/show-manual.c
@@ -45,16 +45,11 @@ static void send_errormsg(int fd, char *format, ...)
    free(msg);
 }
 
-static int recv_errormsg(int fd, char **msg)
-{  char buf[256];
-   int n;
-  
-   n = read(fd, buf, 256);
-   if(!n) return n;
-
-   *msg = g_strdup(buf);
-   
-   return n;
+static const char *recv_errormsg(int fd)
+{  static char buf[256];
+   if (read(fd, buf, 256))
+      return buf;
+   return NULL;
 }
 #endif
 
@@ -65,7 +60,7 @@ void GuiShowURL(char *target)
 
 #if !defined(SYS_MINGW) && !defined(SYS_DARWIN)
    pid_t pid;
-   char *msg;
+   const char *msg;
    int err_pipe[2]; /* child may send down err msgs to us here */
    int result;
 #endif
@@ -165,10 +160,10 @@ void GuiShowURL(char *target)
    /* Parent process. See if some error condition came down the pipe. */
 
    close(err_pipe[1]);
-   result = recv_errormsg(err_pipe[0], &msg);
+   msg = recv_errormsg(err_pipe[0]);
    close(err_pipe[0]);
 
-   if(result)
+   if(msg)
    {  GuiCreateMessage("%s", GTK_MESSAGE_ERROR, msg);
    }
 #endif


### PR DESCRIPTION
Rework the whole AppImage bundling logic for gtk3, and also make the required changes to hopefully fix #92.
The resulting AppImage has so far been tested under Ubuntu 18.04, 20.04, 22.04 and 24.04, without display artifacts.

In the process, also fix the opening of the PDF manual under AppImage, the default path of images and ecc files under AppImage, and a couple other minor quirks.

We also now get Continuous Build binaries for all supported OSes when a PR is merged to the main branch, along with dev builds in a draft release when code is pushed to a "dev" branch (not existing yet).