### PR TITLE
Make speed curve smoother

### DIFF
--- a/src/curve.c
+++ b/src/curve.c
@@ -110,7 +110,7 @@ int GuiCurveLX(Curve *curve, gdouble x)
    return 1 + curve->leftX + (x * width) / (gdouble)curve->maxX;
 }
 
-int GuiCurveY(Curve *curve, gdouble y)
+gdouble GuiCurveY(Curve *curve, gdouble y)
 {  gdouble hfact;
 
    hfact =   (gdouble)(curve->bottomY - curve->topY) 
@@ -380,7 +380,8 @@ void GuiRedrawAxes(cairo_t *cr, Curve *curve)
  */
 
 void GuiRedrawCurve(cairo_t *cr, Curve *curve, int last)
-{  int i,x0,x1,fy0;
+{  int i,x0,x1;
+   gdouble fy0;
 
    gdk_cairo_set_source_rgba(cr, Closure->curveColor);
    cairo_set_line_width(cr, 1.0);

--- a/src/dvdisaster.h
+++ b/src/dvdisaster.h
@@ -690,7 +690,7 @@ void GuiFreeCurve(Curve*);
 void GuiUpdateCurveGeometry(Curve*, char*, int);
 
 int  GuiCurveX(Curve*, gdouble);
-int  GuiCurveY(Curve*, gdouble);
+gdouble GuiCurveY(Curve*, gdouble);
 int  GuiCurveLogY(Curve*, gdouble);
 
 void GuiRedrawAxes(cairo_t *cr, Curve*);


### PR DESCRIPTION
Despite drawing with cairo the speed curve was still a bit staircase-shaped. This is a small change to keep using doubles instead of using an integer for intermediate values.